### PR TITLE
[8.6.0] Fixes up `min` classifier handling

### DIFF
--- a/forgerock-ui-commons/pom.xml
+++ b/forgerock-ui-commons/pom.xml
@@ -182,7 +182,7 @@
 
         <dependency>
             <groupId>org.forgerock.commons.ui.libs</groupId>
-            <artifactId>backbone.paginator.min</artifactId>
+            <artifactId>backbone.paginator</artifactId>
             <classifier>min</classifier>
             <type>js</type>
         </dependency>
@@ -196,40 +196,43 @@
 
         <dependency>
             <groupId>org.forgerock.commons.ui.libs</groupId>
-            <artifactId>backgrid.min</artifactId>
+            <artifactId>backgrid</artifactId>
             <classifier>min</classifier>
             <type>js</type>
         </dependency>
 
         <dependency>
             <groupId>org.forgerock.commons.ui.libs</groupId>
-            <artifactId>backgrid.min</artifactId>
-            <type>less</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.forgerock.commons.ui.libs</groupId>
-            <artifactId>backgrid-paginator.min</artifactId>
+            <artifactId>backgrid</artifactId>
             <classifier>min</classifier>
-            <type>js</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.forgerock.commons.ui.libs</groupId>
-            <artifactId>backgrid-paginator.min</artifactId>
             <type>css</type>
         </dependency>
 
         <dependency>
             <groupId>org.forgerock.commons.ui.libs</groupId>
-            <artifactId>backgrid-filter.min</artifactId>
+            <artifactId>backgrid-paginator</artifactId>
             <classifier>min</classifier>
             <type>js</type>
         </dependency>
 
         <dependency>
             <groupId>org.forgerock.commons.ui.libs</groupId>
-            <artifactId>backgrid-filter.min</artifactId>
+            <artifactId>backgrid-paginator</artifactId>
+            <classifier>min</classifier>
+            <type>css</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.commons.ui.libs</groupId>
+            <artifactId>backgrid-filter</artifactId>
+            <classifier>min</classifier>
+            <type>js</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.forgerock.commons.ui.libs</groupId>
+            <artifactId>backgrid-filter</artifactId>
+            <classifier>min</classifier>
             <type>css</type>
         </dependency>
 

--- a/forgerock-ui-commons/src/main/assembly/zip.xml
+++ b/forgerock-ui-commons/src/main/assembly/zip.xml
@@ -3,6 +3,7 @@
   ~ DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   ~
   ~ Copyright (c) 2011-2012 ForgeRock AS. All Rights Reserved
+  ~ Portions Copyright 2017 Wren Security.
   ~
   ~ The contents of this file are subject to the terms
   ~ of the Common Development and Distribution License
@@ -42,7 +43,6 @@
         <dependencySet>
             <includes>
                 <include>org.forgerock.commons.ui.libs:*:css</include>
-                <include>org.forgerock.commons.ui.libs:*:less</include>
             </includes>
             <outputDirectory>/css</outputDirectory>
         </dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
-                <artifactId>backbone.paginator.min</artifactId>
+                <artifactId>backbone.paginator</artifactId>
                 <version>2.0.2</version>
                 <classifier>min</classifier>
                 <type>js</type>
@@ -275,7 +275,7 @@
             <!-- Libraries for grid support -->
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
-                <artifactId>backgrid.min</artifactId>
+                <artifactId>backgrid</artifactId>
                 <version>0.3.5</version>
                 <classifier>min</classifier>
                 <type>js</type>
@@ -283,29 +283,15 @@
 
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
-                <artifactId>backgrid.min</artifactId>
-                <version>0.3.5</version>
-                <type>less</type>
-            </dependency>
-
-            <dependency>
-                <groupId>org.forgerock.commons.ui.libs</groupId>
-                <artifactId>backgrid-paginator.min</artifactId>
+                <artifactId>backgrid</artifactId>
                 <version>0.3.5</version>
                 <classifier>min</classifier>
-                <type>js</type>
-            </dependency>
-
-            <dependency>
-                <groupId>org.forgerock.commons.ui.libs</groupId>
-                <artifactId>backgrid-paginator.min</artifactId>
-                <version>0.3.5</version>
                 <type>css</type>
             </dependency>
 
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
-                <artifactId>backgrid-filter.min</artifactId>
+                <artifactId>backgrid-paginator</artifactId>
                 <version>0.3.5</version>
                 <classifier>min</classifier>
                 <type>js</type>
@@ -313,8 +299,25 @@
 
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
-                <artifactId>backgrid-filter.min</artifactId>
+                <artifactId>backgrid-paginator</artifactId>
                 <version>0.3.5</version>
+                <classifier>min</classifier>
+                <type>css</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.forgerock.commons.ui.libs</groupId>
+                <artifactId>backgrid-filter</artifactId>
+                <version>0.3.5</version>
+                <classifier>min</classifier>
+                <type>js</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.forgerock.commons.ui.libs</groupId>
+                <artifactId>backgrid-filter</artifactId>
+                <version>0.3.5</version>
+                <classifier>min</classifier>
                 <type>css</type>
             </dependency>
 


### PR DESCRIPTION
`min` is a classifier, NOT part of the package name.