### PR TITLE
Replace 0.3.5 of `backgrid-filter` with 0.3.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
                 <artifactId>backgrid-filter</artifactId>
-                <version>0.3.5</version>
+                <version>0.3.7</version>
                 <classifier>min</classifier>
                 <type>js</type>
             </dependency>
@@ -374,7 +374,7 @@
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
                 <artifactId>backgrid-filter</artifactId>
-                <version>0.3.5</version>
+                <version>0.3.7</version>
                 <classifier>min</classifier>
                 <type>css</type>
             </dependency>


### PR DESCRIPTION
This fixes https://github.com/WrenSecurity/wrensec-deps/issues/7. It looks like ForgeRock had/has a custom version of `backgrid-filter-0.3.5` that includes changes from 0.3.6. This fixes the confusion by dropping 0.3.5 entirely and just using 0.3.7. This is a breaking change for Wren projects that currently are depending on 0.3.5 -- they will need to be updated to 0.3.7.