### PR TITLE
Fix Mock Deps for `min` Classifier Handling

### DIFF
--- a/forgerock-ui-mock/src/main/js/main.js
+++ b/forgerock-ui-mock/src/main/js/main.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2018 Wren Security.
  */
 
 require.config({
@@ -36,11 +37,11 @@ require.config({
         sinon: "libs/sinon-1.15.4",
         i18next: "libs/i18next-1.7.3-min",
         backbone: "libs/backbone-1.1.2-min",
-        "backbone.paginator": "libs/backbone.paginator.min-2.0.2-min",
+        "backbone.paginator": "libs/backbone.paginator-2.0.2-min",
         "backbone-relational": "libs/backbone-relational-0.9.0-min",
-        "backgrid": "libs/backgrid.min-0.3.5-min",
-        "backgrid-filter": "libs/backgrid-filter.min-0.3.5-min",
-        "backgrid-paginator": "libs/backgrid-paginator.min-0.3.5-min",
+        "backgrid": "libs/backgrid-0.3.5-min",
+        "backgrid-filter": "libs/backgrid-filter-0.3.7-min",
+        "backgrid-paginator": "libs/backgrid-paginator-0.3.5-min",
         selectize: "libs/selectize-0.12.1-min",
         lodash: "libs/lodash-3.10.1-min",
         js2form: "libs/js2form-2.0-769718a",

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
                 <artifactId>backgrid-filter</artifactId>
-                <version>0.3.5</version>
+                <version>0.3.7</version>
                 <classifier>min</classifier>
                 <type>js</type>
             </dependency>
@@ -374,7 +374,7 @@
             <dependency>
                 <groupId>org.forgerock.commons.ui.libs</groupId>
                 <artifactId>backgrid-filter</artifactId>
-                <version>0.3.5</version>
+                <version>0.3.7</version>
                 <classifier>min</classifier>
                 <type>css</type>
             </dependency>


### PR DESCRIPTION
Depends on https://github.com/WrenSecurity/wrensec-ui/pull/4.

Updates the path to the dependencies that were renamed when we fixed-up the min classifiers.

ForgeRock's QUnit test suite runs through PhantomJS. PhantomJS fails without halting the build if `libfontconfig` is not installed, which wasn't installed on our build machine, so we didn't realize the tests were failing.