### PR TITLE
Use Wren Security artifact infrastructure

### DIFF
--- a/forgerock-ui-commons/.npmrc
+++ b/forgerock-ui-commons/.npmrc
@@ -1,1 +1,0 @@
-registry = http://maven.forgerock.org/repo/api/npm/npm-virtual/

--- a/forgerock-ui-mock/.npmrc
+++ b/forgerock-ui-mock/.npmrc
@@ -1,1 +1,0 @@
-registry = http://maven.forgerock.org/repo/api/npm/npm-virtual/

--- a/forgerock-ui-user/.npmrc
+++ b/forgerock-ui-user/.npmrc
@@ -1,1 +1,0 @@
-registry = http://maven.forgerock.org/repo/api/npm/npm-virtual/

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>0.0.27</version>
+                    <version>0.0.28</version>
                     <configuration>
                         <installDirectory>${node.install.directory}</installDirectory>
                     </configuration>
@@ -119,9 +119,10 @@
                             </goals>
                             <phase>initialize</phase>
                             <configuration>
-                                <nodeVersion>v4.2.6</nodeVersion>
-                                <npmVersion>3.5.3</npmVersion>
-                                <npmDownloadRoot>http://maven.forgerock.org/repo/api/npm/npm-virtual/npm/-/</npmDownloadRoot>
+                                <nodeVersion>v4.4.5</nodeVersion>
+                                <npmVersion>3.9.3</npmVersion>
+                                <downloadRoot>https://nodejs.org/dist/</downloadRoot>
+                                <npmDownloadRoot>https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/npm/-/</npmDownloadRoot>
                             </configuration>
                         </execution>
 
@@ -131,9 +132,6 @@
                                 <goal>npm</goal>
                             </goals>
                             <phase>initialize</phase>
-                            <configuration>
-                                <arguments>install</arguments>
-                            </configuration>
                         </execution>
 
                         <execution>
@@ -143,7 +141,7 @@
                             </goals>
                             <phase>compile</phase>
                             <configuration>
-                                <arguments>build</arguments>
+                                <arguments>build --debug --verbose</arguments>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
Do not use FR repository manager for NPM packages. Fixes #6.

@Kortanul Could you test if this works on your machine? I'm getting this error:
```
[INFO] >> PhantomJS timed out, possibly due to a missing QUnit start() call.
```
However I suspect this is due to some proxy settings on my machine even though I think I removed those (see: https://github.com/gruntjs/grunt/issues/345). I did some digging but still couldn't find it. So before I waste anymore time on this I would like to know if these aren't my proxy settings.