### PR TITLE
Remove dependency on ForgeRock's NPM registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-dist/
 docs
 node_modules
 node/

--- a/forgerock-ui-commons/.npmrc
+++ b/forgerock-ui-commons/.npmrc
@@ -1,0 +1,1 @@
+registry = https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/

--- a/forgerock-ui-commons/Gruntfile.js
+++ b/forgerock-ui-commons/Gruntfile.js
@@ -37,49 +37,49 @@ module.exports = function (grunt) {
             main: {
                 files: [
                     // JS - npm
-                    { src: "node_modules/backbone/backbone-min.js", dest: "dist/libs/backbone-1.1.2-min.js" },
-                    { src: "node_modules/backbone-relational/backbone-relational.js", dest: "dist/libs/backbone-relational-0.9.0-min.js" }, // Not actually minified
-                    { src: "node_modules/backbone.paginator/lib/backbone.paginator.min.js", dest: "dist/libs/backbone.paginator-2.0.2-min.js" },
-                    { src: "node_modules/backgrid/lib/backgrid.min.js", dest: "dist/libs/backgrid-0.3.5-min.js" },
-                    { src: "node_modules/backgrid-filter/backgrid-filter.min.js", dest: "dist/libs/backgrid-filter-0.3.7-min.js" },
-                    { src: "node_modules/backgrid-paginator/backgrid-paginator.min.js", dest: "dist/libs/backgrid-paginator-0.3.5-min.js" },
-                    { src: "node_modules/backgrid-select-all/backgrid-select-all.min.js", dest: "dist/libs/backgrid-select-all-0.3.5-min.js" },
-                    { src: "node_modules/dragula/dist/dragula.min.js", dest: "dist/libs/dragula-3.6.7-min.js" },
-                    { src: "node_modules/i18next/lib/dep/i18next.min.js", dest: "dist/libs/i18next-1.7.3-min.js" },
-                    { src: "node_modules/jquery/dist/jquery.min.js", dest: "dist/libs/jquery-2.1.1-min.js" },
-                    { src: "node_modules/moment/min/moment.min.js", dest: "dist/libs/moment-2.8.1-min.js" },
-                    { src: "node_modules/requirejs/require.js", dest: "dist/libs/requirejs-2.1.14-min.js" }, // Not actually minified
-                    { src: "node_modules/spin.js/spin.js", dest: "dist/libs/spin-2.0.1-min.js" }, // Not actually minified
-                    { src: "node_modules/xdate/src/xdate.js", dest: "dist/libs/xdate-0.8-min.js" }, // Not actually minified
-                    { src: "node_modules/react/dist/react.min.js", dest: "dist/libs/react-15.2.1-min.js" },
-                    { src: "node_modules/react-dom/dist/react-dom.min.js", dest: "dist/libs/react-dom-15.2.1-min.js" },
-                    { src: "node_modules/handlebars/dist/handlebars.js", dest: "dist/libs/handlebars-4.0.5.js" }, // Not mified but could be
+                    { src: "node_modules/backbone/backbone-min.js", dest: "target/frontend-libs/libs/backbone-1.1.2-min.js" },
+                    { src: "node_modules/backbone-relational/backbone-relational.js", dest: "target/frontend-libs/libs/backbone-relational-0.9.0-min.js" }, // Not actually minified
+                    { src: "node_modules/backbone.paginator/lib/backbone.paginator.min.js", dest: "target/frontend-libs/libs/backbone.paginator-2.0.2-min.js" },
+                    { src: "node_modules/backgrid/lib/backgrid.min.js", dest: "target/frontend-libs/libs/backgrid-0.3.5-min.js" },
+                    { src: "node_modules/backgrid-filter/backgrid-filter.min.js", dest: "target/frontend-libs/libs/backgrid-filter-0.3.7-min.js" },
+                    { src: "node_modules/backgrid-paginator/backgrid-paginator.min.js", dest: "target/frontend-libs/libs/backgrid-paginator-0.3.5-min.js" },
+                    { src: "node_modules/backgrid-select-all/backgrid-select-all.min.js", dest: "target/frontend-libs/libs/backgrid-select-all-0.3.5-min.js" },
+                    { src: "node_modules/dragula/dist/dragula.min.js", dest: "target/frontend-libs/libs/dragula-3.6.7-min.js" },
+                    { src: "node_modules/i18next/lib/dep/i18next.min.js", dest: "target/frontend-libs/libs/i18next-1.7.3-min.js" },
+                    { src: "node_modules/jquery/dist/jquery.min.js", dest: "target/frontend-libs/libs/jquery-2.1.1-min.js" },
+                    { src: "node_modules/moment/min/moment.min.js", dest: "target/frontend-libs/libs/moment-2.8.1-min.js" },
+                    { src: "node_modules/requirejs/require.js", dest: "target/frontend-libs/libs/requirejs-2.1.14-min.js" }, // Not actually minified
+                    { src: "node_modules/spin.js/spin.js", dest: "target/frontend-libs/libs/spin-2.0.1-min.js" }, // Not actually minified
+                    { src: "node_modules/xdate/src/xdate.js", dest: "target/frontend-libs/libs/xdate-0.8-min.js" }, // Not actually minified
+                    { src: "node_modules/react/dist/react.min.js", dest: "target/frontend-libs/libs/react-15.2.1-min.js" },
+                    { src: "node_modules/react-dom/dist/react-dom.min.js", dest: "target/frontend-libs/libs/react-dom-15.2.1-min.js" },
+                    { src: "node_modules/handlebars/dist/handlebars.js", dest: "target/frontend-libs/libs/handlebars-4.0.5.js" }, // Not mified but could be
 
                     // JS - custom
-                    { src: "libs/js/bootstrap-3.3.5-custom.js", dest: "dist/libs/bootstrap-3.3.5-custom.js" },
-                    { src: "libs/js/bootstrap-dialog-1.34.4-min.js", dest: "dist/libs/bootstrap-dialog-1.34.4-min.js" },
-                    { src: "libs/js/form2js-2.0-769718a.js", dest: "dist/libs/form2js-2.0-769718a.js" },
-                    { src: "libs/js/jquery.ba-dotimeout-1.0-min.js", dest: "dist/libs/jquery.ba-dotimeout-1.0-min.js" },
-                    { src: "libs/js/jquery.placeholder-2.0.8.js", dest: "dist/libs/jquery.placeholder-2.0.8.js" },
-                    { src: "libs/js/js2form-2.0-769718a.js", dest: "dist/libs/js2form-2.0-769718a.js" },
-                    { src: "libs/js/lodash-3.10.1-min.js", dest: "dist/libs/lodash-3.10.1-min.js" },
-                    { src: "libs/js/selectize-0.12.1-min.js", dest: "dist/libs/selectize-0.12.1-min.js" },
+                    { src: "libs/js/bootstrap-3.3.5-custom.js", dest: "target/frontend-libs/libs/bootstrap-3.3.5-custom.js" },
+                    { src: "libs/js/bootstrap-dialog-1.34.4-min.js", dest: "target/frontend-libs/libs/bootstrap-dialog-1.34.4-min.js" },
+                    { src: "libs/js/form2js-2.0-769718a.js", dest: "target/frontend-libs/libs/form2js-2.0-769718a.js" },
+                    { src: "libs/js/jquery.ba-dotimeout-1.0-min.js", dest: "target/frontend-libs/libs/jquery.ba-dotimeout-1.0-min.js" },
+                    { src: "libs/js/jquery.placeholder-2.0.8.js", dest: "target/frontend-libs/libs/jquery.placeholder-2.0.8.js" },
+                    { src: "libs/js/js2form-2.0-769718a.js", dest: "target/frontend-libs/libs/js2form-2.0-769718a.js" },
+                    { src: "libs/js/lodash-3.10.1-min.js", dest: "target/frontend-libs/libs/lodash-3.10.1-min.js" },
+                    { src: "libs/js/selectize-0.12.1-min.js", dest: "target/frontend-libs/libs/selectize-0.12.1-min.js" },
 
                     // CSS - npm
-                    { src: "node_modules/backgrid/lib/backgrid.min.css", dest: "dist/css/backgrid-0.3.5-min.css" },
-                    { src: "node_modules/backgrid-filter/backgrid-filter.css", dest: "dist/css/backgrid-filter-0.3.7-min.css" },
-                    { src: "node_modules/backgrid-paginator/backgrid-paginator.min.css", dest: "dist/css/backgrid-paginator-0.3.5-min.css" },
-                    { src: "node_modules/titatoggle/dist/titatoggle-dist-min.css", dest: "dist/css/titatoggle-1.2.6-min.css" }, // Actually 1.2.15
+                    { src: "node_modules/backgrid/lib/backgrid.min.css", dest: "target/frontend-libs/css/backgrid-0.3.5-min.css" },
+                    { src: "node_modules/backgrid-filter/backgrid-filter.css", dest: "target/frontend-libs/css/backgrid-filter-0.3.7-min.css" },
+                    { src: "node_modules/backgrid-paginator/backgrid-paginator.min.css", dest: "target/frontend-libs/css/backgrid-paginator-0.3.5-min.css" },
+                    { src: "node_modules/titatoggle/dist/titatoggle-dist-min.css", dest: "target/frontend-libs/css/titatoggle-1.2.6-min.css" }, // Actually 1.2.15
 
                     // CSS - custom
-                    { src: "libs/css/bootstrap-3.3.5-custom.css", dest: "dist/css/bootstrap-3.3.5-custom.css" },
-                    { src: "libs/css/bootstrap-dialog-1.34.4-min.css", dest: "dist/css/bootstrap-dialog-1.34.4-min.css" },
-                    { src: "libs/css/selectize-0.12.1-bootstrap3.css", dest: "dist/css/selectize-0.12.1-bootstrap3.css" },
+                    { src: "libs/css/bootstrap-3.3.5-custom.css", dest: "target/frontend-libs/css/bootstrap-3.3.5-custom.css" },
+                    { src: "libs/css/bootstrap-dialog-1.34.4-min.css", dest: "target/frontend-libs/css/bootstrap-dialog-1.34.4-min.css" },
+                    { src: "libs/css/selectize-0.12.1-bootstrap3.css", dest: "target/frontend-libs/css/selectize-0.12.1-bootstrap3.css" },
 
                     // Fontawesome
-                    { src: "node_modules/font-awesome/css/font-awesome.min.css", dest: "dist/css/fontawesome/css/font-awesome.min.css" },
-                    { src: "node_modules/font-awesome/less/variables.less", dest: "dist/css/fontawesome/less/variables.less" },
-                    { expand: true, flatten: true, src: "node_modules/font-awesome/fonts/*", dest: "dist/css/fontawesome/fonts/" },
+                    { src: "node_modules/font-awesome/css/font-awesome.min.css", dest: "target/frontend-libs/css/fontawesome/css/font-awesome.min.css" },
+                    { src: "node_modules/font-awesome/less/variables.less", dest: "target/frontend-libs/css/fontawesome/less/variables.less" },
+                    { expand: true, flatten: true, src: "node_modules/font-awesome/fonts/*", dest: "target/frontend-libs/css/fontawesome/fonts/" },
                 ],
             },
         },

--- a/forgerock-ui-commons/package-lock.json
+++ b/forgerock-ui-commons/package-lock.json
@@ -5,13 +5,13 @@
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "optional": true,
       "requires": {
@@ -22,29 +22,29 @@
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "ansicolors": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansicolors/-/ansicolors-0.2.1.tgz",
       "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
@@ -53,23 +53,23 @@
     },
     "asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "async": {
       "version": "0.1.22",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/async/-/async-0.1.22.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/async/-/async-0.1.22.tgz",
       "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
       "dev": true
     },
     "atoa": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/atoa/-/atoa-1.0.0.tgz",
       "integrity": "sha1-DMDpGkgOc4+SPrwQNnZHF3mzSkk="
     },
     "backbone": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backbone/-/backbone-1.1.2.tgz",
       "integrity": "sha1-wsBMZr+HJo+4LBd6zr7/fTe6by0=",
       "requires": {
         "underscore": ">=1.5.0"
@@ -77,7 +77,7 @@
     },
     "backbone-relational": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/backbone-relational/-/backbone-relational-0.9.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backbone-relational/-/backbone-relational-0.9.0.tgz",
       "integrity": "sha1-c7shf4feYcWvFLoDtx9INgoe1II=",
       "requires": {
         "backbone": ">=1.1.2",
@@ -86,7 +86,7 @@
     },
     "backbone.paginator": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/backbone.paginator/-/backbone.paginator-2.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backbone.paginator/-/backbone.paginator-2.0.2.tgz",
       "integrity": "sha1-836BfpftXRFS9nOEy/3OFlSldY8=",
       "requires": {
         "backbone": "^1.1.2",
@@ -95,7 +95,7 @@
     },
     "backgrid": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/backgrid/-/backgrid-0.3.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backgrid/-/backgrid-0.3.5.tgz",
       "integrity": "sha1-igmXcu/b1c8XDGyQXMqLKj/ZhNI=",
       "requires": {
         "backbone": "~1.1.0",
@@ -104,14 +104,14 @@
       "dependencies": {
         "underscore": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore/-/underscore-1.5.2.tgz",
           "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg="
         }
       }
     },
     "backgrid-filter": {
       "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/backgrid-filter/-/backgrid-filter-0.3.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backgrid-filter/-/backgrid-filter-0.3.7.tgz",
       "integrity": "sha1-1LGdDnBwE9fxgfnox/67SZfVbwM=",
       "requires": {
         "backbone": "~1.2.3",
@@ -122,7 +122,7 @@
       "dependencies": {
         "backbone": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backbone/-/backbone-1.2.3.tgz",
           "integrity": "sha1-wiz9B/yG676uYdGJKe0RXpmdZbk=",
           "requires": {
             "underscore": ">=1.7.0"
@@ -130,7 +130,7 @@
         },
         "backgrid": {
           "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/backgrid/-/backgrid-0.3.8.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backgrid/-/backgrid-0.3.8.tgz",
           "integrity": "sha1-fSaBZ0LXLIWcrTmxPxnJ8nuv/tc=",
           "requires": {
             "backbone": "1.1.2 || 1.2.3 || ~1.3.2",
@@ -139,42 +139,42 @@
         },
         "underscore": {
           "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore/-/underscore-1.13.1.tgz",
           "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
         }
       }
     },
     "backgrid-paginator": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/backgrid-paginator/-/backgrid-paginator-0.3.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backgrid-paginator/-/backgrid-paginator-0.3.5.tgz",
       "integrity": "sha1-cnl1ixI4qwMFasLySBIPOqZ7elo="
     },
     "backgrid-select-all": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/backgrid-select-all/-/backgrid-select-all-0.3.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/backgrid-select-all/-/backgrid-select-all-0.3.5.tgz",
       "integrity": "sha1-FDqADl2V/yrlqE14v0+6QflIHpQ="
     },
     "balanced-match": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true
     },
     "bindings": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/bindings/-/bindings-1.2.1.tgz",
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
       "optional": true
     },
     "bluebird": {
       "version": "2.9.34",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/bluebird/-/bluebird-2.9.34.tgz",
       "integrity": "sha1-L3tOyAIWMoqf3evfacjUlC/v99g=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
@@ -184,19 +184,19 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "optional": true
     },
     "cardinal": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/cardinal/-/cardinal-0.4.4.tgz",
       "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
       "requires": {
         "ansicolors": "~0.2.1",
@@ -205,7 +205,7 @@
     },
     "catharsis": {
       "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/catharsis/-/catharsis-0.8.11.tgz",
       "integrity": "sha1-0Os9K4K32no84u+xp7AL7MZkNGg=",
       "dev": true,
       "requires": {
@@ -214,7 +214,7 @@
       "dependencies": {
         "lodash": {
           "version": "4.17.21",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-4.17.21.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.17.21.tgz",
           "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
           "dev": true
         }
@@ -222,7 +222,7 @@
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "optional": true,
       "requires": {
@@ -232,7 +232,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -245,19 +245,19 @@
     },
     "circular-json": {
       "version": "0.3.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/circular-json/-/circular-json-0.3.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-width": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cli-width/-/cli-width-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/cli-width/-/cli-width-1.1.1.tgz",
       "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
       "dev": true
     },
     "cliui": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "optional": true,
       "requires": {
@@ -268,7 +268,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "optional": true
         }
@@ -276,25 +276,25 @@
     },
     "coffee-script": {
       "version": "1.3.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/coffee-script/-/coffee-script-1.3.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/coffee-script/-/coffee-script-1.3.3.tgz",
       "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
       "dev": true
     },
     "colors": {
       "version": "0.6.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/colors/-/colors-0.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
@@ -306,7 +306,7 @@
     },
     "contra": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/contra/-/contra-1.9.1.tgz",
       "integrity": "sha1-YOSYJ0s9LTMoltYPgpAK76LsrIw=",
       "requires": {
         "atoa": "1.0.0",
@@ -315,7 +315,7 @@
     },
     "cookies": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/cookies/-/cookies-0.8.0.tgz",
       "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
       "requires": {
         "depd": "~2.0.0",
@@ -324,18 +324,18 @@
     },
     "core-js": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "crossvent": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/crossvent/-/crossvent-1.5.4.tgz",
       "integrity": "sha1-2ixPj0DJR4JRe/K+7BBEFIGUq5I=",
       "requires": {
         "custom-event": "1.0.0"
@@ -343,12 +343,12 @@
     },
     "custom-event": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/custom-event/-/custom-event-1.0.0.tgz",
       "integrity": "sha1-LkYovhncSyFLXAJjDFlx6BFhgGI="
     },
     "d": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/d/-/d-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/d/-/d-1.0.1.tgz",
       "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
       "dev": true,
       "requires": {
@@ -358,13 +358,13 @@
     },
     "dateformat": {
       "version": "1.0.2-1.2.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
       "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
       "dev": true
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "requires": {
@@ -373,24 +373,24 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
     "doctrine": {
       "version": "0.7.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/doctrine/-/doctrine-0.7.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/doctrine/-/doctrine-0.7.2.tgz",
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
@@ -400,7 +400,7 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
@@ -408,7 +408,7 @@
     },
     "dragula": {
       "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/dragula/-/dragula-3.6.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/dragula/-/dragula-3.6.7.tgz",
       "integrity": "sha1-Z7oIroxrHZHM+rP+ZqVXkLrt3cU=",
       "requires": {
         "contra": "1.9.1",
@@ -417,7 +417,7 @@
     },
     "encoding": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "requires": {
         "iconv-lite": "^0.6.2"
@@ -425,7 +425,7 @@
       "dependencies": {
         "iconv-lite": {
           "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -435,7 +435,7 @@
     },
     "es5-ext": {
       "version": "0.10.53",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.53.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
       "dev": true,
       "requires": {
@@ -446,7 +446,7 @@
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
@@ -457,7 +457,7 @@
     },
     "es6-map": {
       "version": "0.1.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-map/-/es6-map-0.1.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
@@ -471,7 +471,7 @@
     },
     "es6-set": {
       "version": "0.1.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-set/-/es6-set-0.1.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
@@ -484,7 +484,7 @@
       "dependencies": {
         "es6-symbol": {
           "version": "3.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "dev": true,
           "requires": {
@@ -496,7 +496,7 @@
     },
     "es6-symbol": {
       "version": "3.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
       "dev": true,
       "requires": {
@@ -506,7 +506,7 @@
     },
     "es6-weak-map": {
       "version": "2.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha1-ttofFswswNm+Q+a9v8Xn383zHVM=",
       "dev": true,
       "requires": {
@@ -518,13 +518,13 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
@@ -536,7 +536,7 @@
     },
     "eslint": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint/-/eslint-1.5.1.tgz",
       "integrity": "sha1-u54WHwFh1xuF3EgWO/FKhvICVis=",
       "dev": true,
       "requires": {
@@ -577,13 +577,13 @@
     },
     "eslint-config-forgerock": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-forgerock/-/eslint-config-forgerock-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint-config-forgerock/-/eslint-config-forgerock-1.0.0.tgz",
       "integrity": "sha1-hhQV5Y2lq3yGBdAXasgTVEKo2Mc=",
       "dev": true
     },
     "eslint-formatter-warning-summary": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-warning-summary/-/eslint-formatter-warning-summary-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint-formatter-warning-summary/-/eslint-formatter-warning-summary-1.0.1.tgz",
       "integrity": "sha1-6Xe7j+srOgl44Ue5WziXp29TZHs=",
       "dev": true,
       "requires": {
@@ -593,13 +593,13 @@
     },
     "espree": {
       "version": "2.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz",
       "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
       "dev": true
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "requires": {
@@ -608,7 +608,7 @@
       "dependencies": {
         "estraverse": {
           "version": "5.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse/-/estraverse-5.2.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
           "dev": true
         }
@@ -616,25 +616,25 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "estraverse-fb": {
       "version": "1.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
       "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
       "dev": true
     },
     "esutils": {
       "version": "1.1.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz",
       "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
@@ -644,19 +644,19 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "ext": {
       "version": "1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ext/-/ext-1.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ext/-/ext-1.4.0.tgz",
       "integrity": "sha1-ia56BxWPedNVF4gpBDJAd+Q3kkQ=",
       "dev": true,
       "requires": {
@@ -665,7 +665,7 @@
       "dependencies": {
         "type": {
           "version": "2.5.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type/-/type-2.5.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type/-/type-2.5.0.tgz",
           "integrity": "sha1-Ci54wud5B7JSq+XymMGwHGPw2z0=",
           "dev": true
         }
@@ -673,13 +673,13 @@
     },
     "fast-levenshtein": {
       "version": "1.0.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
       "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
       "dev": true
     },
     "fbjs": {
       "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "requires": {
         "core-js": "^1.0.0",
@@ -693,14 +693,14 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         }
       }
     },
     "figures": {
       "version": "1.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/figures/-/figures-1.7.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
@@ -710,7 +710,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
@@ -718,7 +718,7 @@
     },
     "file-entry-cache": {
       "version": "1.3.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
@@ -728,7 +728,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
@@ -736,13 +736,13 @@
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
       "dev": true
     },
     "findup-sync": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/findup-sync/-/findup-sync-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/findup-sync/-/findup-sync-0.1.3.tgz",
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
@@ -752,7 +752,7 @@
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -762,13 +762,13 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -780,7 +780,7 @@
     },
     "flat-cache": {
       "version": "1.3.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/flat-cache/-/flat-cache-1.3.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha1-LC73dSXMKSkAff/6HdMUqpyd7m8=",
       "dev": true,
       "requires": {
@@ -792,7 +792,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.6",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-7.1.6.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.6.tgz",
           "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
           "dev": true,
           "requires": {
@@ -806,7 +806,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
@@ -815,7 +815,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
           "dev": true,
           "requires": {
@@ -826,18 +826,18 @@
     },
     "font-awesome": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.5.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/font-awesome/-/font-awesome-4.5.0.tgz",
       "integrity": "sha1-Hp18z31jvb5XAA4Y1RiMslV+cPg="
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "generate-function": {
       "version": "2.3.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/generate-function/-/generate-function-2.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
       "dev": true,
       "requires": {
@@ -846,7 +846,7 @@
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
@@ -855,19 +855,19 @@
     },
     "get-stdin": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/get-stdin/-/get-stdin-3.0.2.tgz",
       "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4=",
       "dev": true
     },
     "getobject": {
       "version": "0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/getobject/-/getobject-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
     "glob": {
       "version": "5.0.15",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
@@ -880,19 +880,19 @@
     },
     "globals": {
       "version": "8.18.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz",
       "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
       "dev": true
     },
     "graceful-fs": {
       "version": "4.2.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
       "dev": true
     },
     "grunt": {
       "version": "0.4.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt/-/grunt-0.4.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
@@ -920,7 +920,7 @@
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/argparse/-/argparse-0.1.16.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
@@ -930,7 +930,7 @@
           "dependencies": {
             "underscore.string": {
               "version": "2.4.0",
-              "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.4.0.tgz",
+              "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.4.0.tgz",
               "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
               "dev": true
             }
@@ -938,13 +938,13 @@
         },
         "esprima": {
           "version": "1.0.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         },
         "glob": {
           "version": "3.1.21",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.1.21.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
@@ -955,19 +955,19 @@
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "inherits": {
           "version": "1.0.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inherits/-/inherits-1.0.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
         "js-yaml": {
           "version": "2.0.5",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/js-yaml/-/js-yaml-2.0.5.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-2.0.5.tgz",
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
@@ -977,13 +977,13 @@
         },
         "lodash": {
           "version": "0.9.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
@@ -993,7 +993,7 @@
         },
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -1001,7 +1001,7 @@
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
       "dev": true,
       "requires": {
@@ -1012,7 +1012,7 @@
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
@@ -1022,7 +1022,7 @@
     },
     "grunt-eslint": {
       "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-eslint/-/grunt-eslint-17.3.1.tgz",
       "integrity": "sha1-w7UOENnF9dc9g/RnePgDb4SpY60=",
       "dev": true,
       "requires": {
@@ -1032,7 +1032,7 @@
     },
     "grunt-legacy-log": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
       "requires": {
@@ -1045,13 +1045,13 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -1059,7 +1059,7 @@
     },
     "grunt-legacy-log-utils": {
       "version": "0.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
       "requires": {
@@ -1070,13 +1070,13 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -1084,7 +1084,7 @@
     },
     "grunt-legacy-util": {
       "version": "0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
       "requires": {
@@ -1099,7 +1099,7 @@
       "dependencies": {
         "lodash": {
           "version": "0.9.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         }
@@ -1107,7 +1107,7 @@
     },
     "handlebars": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/handlebars/-/handlebars-4.0.5.tgz",
       "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
       "requires": {
         "async": "^1.4.0",
@@ -1118,14 +1118,14 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -1134,18 +1134,18 @@
     },
     "hooker": {
       "version": "0.2.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/hooker/-/hooker-0.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
     "humanize": {
       "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/humanize/-/humanize-0.0.9.tgz",
       "integrity": "sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ="
     },
     "i18next": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-1.7.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/i18next/-/i18next-1.7.3.tgz",
       "integrity": "sha1-igZIZsjm6HtGZKMv6Bub40tKOJQ=",
       "requires": {
         "cookies": ">= 0.2.2"
@@ -1153,13 +1153,13 @@
     },
     "iconv-lite": {
       "version": "0.2.11",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.2.11.tgz",
       "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -1169,13 +1169,13 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "inquirer": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inquirer/-/inquirer-0.9.0.tgz",
       "integrity": "sha1-c2bjijMeYZBJWKzlstpKml9jZ5g=",
       "dev": true,
       "requires": {
@@ -1193,19 +1193,19 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "optional": true
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
       "dev": true
     },
     "is-my-json-valid": {
       "version": "2.20.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
       "integrity": "sha1-XspqgjKmh/aIabc2G+FhLnUS5d8=",
       "dev": true,
       "requires": {
@@ -1218,30 +1218,30 @@
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
         "node-fetch": "^1.0.1",
@@ -1250,17 +1250,17 @@
     },
     "jquery": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/jquery/-/jquery-2.1.1.tgz",
       "integrity": "sha1-go/GD1D37lmDNj706wHF9wr0vVs="
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
       "dev": true,
       "requires": {
@@ -1270,7 +1270,7 @@
       "dependencies": {
         "esprima": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esprima/-/esprima-4.0.1.tgz",
           "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
           "dev": true
         }
@@ -1278,13 +1278,13 @@
     },
     "js2xmlparser": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
       "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA=",
       "dev": true
     },
     "jsdoc": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/jsdoc/-/jsdoc-3.4.0.tgz",
       "integrity": "sha1-NBzbBuRKET2VQe/SEslaSIBk6e4=",
       "dev": true,
       "requires": {
@@ -1304,13 +1304,13 @@
       "dependencies": {
         "async": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/async/-/async-1.4.2.tgz",
           "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
           "dev": true
         },
         "underscore": {
           "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
           "dev": true
         }
@@ -1318,13 +1318,13 @@
     },
     "jsonpointer": {
       "version": "4.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/jsonpointer/-/jsonpointer-4.1.0.tgz",
       "integrity": "sha1-UB+4mYaiOJdlugnmBTKZzrTywsw=",
       "dev": true
     },
     "keygrip": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/keygrip/-/keygrip-1.1.0.tgz",
       "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
       "requires": {
         "tsscmp": "1.0.6"
@@ -1332,7 +1332,7 @@
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "optional": true,
       "requires": {
@@ -1341,13 +1341,13 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "optional": true
     },
     "levn": {
       "version": "0.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/levn/-/levn-0.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/levn/-/levn-0.2.5.tgz",
       "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
       "dev": true,
       "requires": {
@@ -1357,31 +1357,31 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
       "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
       "dev": true
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
       "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
       "dev": true
     },
     "lodash._arraymap": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
       "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
@@ -1391,7 +1391,7 @@
     },
     "lodash._baseclone": {
       "version": "3.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "dev": true,
       "requires": {
@@ -1405,13 +1405,13 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basedifference": {
       "version": "3.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
       "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
       "dev": true,
       "requires": {
@@ -1422,7 +1422,7 @@
     },
     "lodash._baseflatten": {
       "version": "3.1.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
       "dev": true,
       "requires": {
@@ -1432,31 +1432,31 @@
     },
     "lodash._basefor": {
       "version": "3.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
       "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
       "dev": true
     },
     "lodash._baseindexof": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
       "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
       "dev": true
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "dev": true
     },
     "lodash._cacheindexof": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
       "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
       "dev": true
     },
     "lodash._createassigner": {
       "version": "3.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
@@ -1467,7 +1467,7 @@
     },
     "lodash._createcache": {
       "version": "3.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
       "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
       "dev": true,
       "requires": {
@@ -1476,25 +1476,25 @@
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash._pickbyarray": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
       "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
       "dev": true
     },
     "lodash._pickbycallback": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
       "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
       "dev": true,
       "requires": {
@@ -1504,7 +1504,7 @@
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
       "dev": true,
       "requires": {
@@ -1514,19 +1514,19 @@
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "3.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
       "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
       "dev": true,
       "requires": {
@@ -1537,13 +1537,13 @@
     },
     "lodash.istypedarray": {
       "version": "3.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
       "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -1554,7 +1554,7 @@
     },
     "lodash.keysin": {
       "version": "3.0.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
       "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
       "dev": true,
       "requires": {
@@ -1564,7 +1564,7 @@
     },
     "lodash.merge": {
       "version": "3.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.merge/-/lodash.merge-3.3.2.tgz",
       "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
       "dev": true,
       "requires": {
@@ -1583,7 +1583,7 @@
     },
     "lodash.omit": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.omit/-/lodash.omit-3.1.0.tgz",
       "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
       "dev": true,
       "requires": {
@@ -1599,13 +1599,13 @@
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
       "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
       "dev": true,
       "requires": {
@@ -1615,13 +1615,13 @@
     },
     "longest": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -1629,29 +1629,29 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "lunr": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-0.7.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lunr/-/lunr-0.7.2.tgz",
       "integrity": "sha1-eaMOky4hbLoWNUHuN6NgfBLNcoE="
     },
     "marked": {
       "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/marked/-/marked-0.3.19.tgz",
       "integrity": "sha1-XUf3CcTJ/Dwha21GEnKA9As515A=",
       "dev": true
     },
     "microplugin": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/microplugin/-/microplugin-0.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/microplugin/-/microplugin-0.0.3.tgz",
       "integrity": "sha1-H8Lhu3yeGegr2Eu6kTe75xJQ2M0="
     },
     "microtime": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/microtime/-/microtime-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/microtime/-/microtime-2.0.0.tgz",
       "integrity": "sha1-E/kP1MiRoG2rD9dJTbIrDxj+Zrs=",
       "optional": true,
       "requires": {
@@ -1661,7 +1661,7 @@
     },
     "minimatch": {
       "version": "2.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "dev": true,
       "requires": {
@@ -1670,13 +1670,13 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimist/-/minimist-1.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
@@ -1685,30 +1685,30 @@
     },
     "moment": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.8.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/moment/-/moment-2.8.1.tgz",
       "integrity": "sha1-L8ccIWxArytLVDyxaLqaX1KZaw8="
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mute-stream/-/mute-stream-0.0.4.tgz",
       "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
       "dev": true
     },
     "nan": {
       "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/nan/-/nan-2.0.9.tgz",
       "integrity": "sha1-0Cp3D0Z3iELM65ThfKsx/8cjSgU=",
       "optional": true
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -1718,7 +1718,7 @@
     },
     "node-fetch": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "^0.1.11",
@@ -1727,7 +1727,7 @@
     },
     "nopt": {
       "version": "1.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/nopt/-/nopt-1.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
@@ -1736,13 +1736,13 @@
     },
     "object-assign": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-2.1.1.tgz",
       "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -1751,7 +1751,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
         "minimist": "~0.0.1",
@@ -1760,14 +1760,14 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }
     },
     "optionator": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/optionator/-/optionator-0.5.0.tgz",
       "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
       "dev": true,
       "requires": {
@@ -1781,7 +1781,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -1789,31 +1789,31 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "promise": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
@@ -1821,7 +1821,7 @@
     },
     "react": {
       "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/react/-/react-15.2.1.tgz",
       "integrity": "sha1-5FjfcAuucpALoyZzt+Qujb0Fo5M=",
       "requires": {
         "fbjs": "^0.8.1",
@@ -1831,19 +1831,19 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         }
       }
     },
     "react-dom": {
       "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/react-dom/-/react-dom-15.2.1.tgz",
       "integrity": "sha1-3JQqUmj5VeGAFYydTSYJ/sk4j/A="
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "dev": true,
       "requires": {
@@ -1858,7 +1858,7 @@
     },
     "readline2": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/readline2/-/readline2-0.1.1.tgz",
       "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
       "dev": true,
       "requires": {
@@ -1868,13 +1868,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-1.1.1.tgz",
           "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
           "dev": true
         },
         "strip-ansi": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
           "dev": true,
           "requires": {
@@ -1885,7 +1885,7 @@
     },
     "redeyed": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/redeyed/-/redeyed-0.4.4.tgz",
       "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
       "requires": {
         "esprima": "~1.0.4"
@@ -1893,25 +1893,25 @@
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
         }
       }
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "optional": true
     },
     "requirejs": {
       "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.14.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/requirejs/-/requirejs-2.1.14.tgz",
       "integrity": "sha1-3gApCqUmGS/4303AupNwzjmadrA="
     },
     "requizzle": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/requizzle/-/requizzle-0.2.3.tgz",
       "integrity": "sha1-RnXJCqyvssA2vTm6LapKHLd3/e0=",
       "dev": true,
       "requires": {
@@ -1920,7 +1920,7 @@
       "dependencies": {
         "lodash": {
           "version": "4.17.21",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-4.17.21.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-4.17.21.tgz",
           "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
           "dev": true
         }
@@ -1928,13 +1928,13 @@
     },
     "resolve": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/resolve/-/resolve-0.3.1.tgz",
       "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
       "dev": true
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "optional": true,
       "requires": {
@@ -1943,7 +1943,7 @@
     },
     "rimraf": {
       "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.5.3.tgz",
       "integrity": "sha1-bl792kqi8DQX9rKldK7Cn0tlJwU=",
       "dev": true,
       "requires": {
@@ -1952,7 +1952,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.6",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-7.1.6.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.6.tgz",
           "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
           "dev": true,
           "requires": {
@@ -1966,7 +1966,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
@@ -1977,7 +1977,7 @@
     },
     "run-async": {
       "version": "0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
@@ -1986,24 +1986,24 @@
     },
     "rx-lite": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rx-lite/-/rx-lite-2.5.2.tgz",
       "integrity": "sha1-X+9C1Nbna6tRmdIXEyfbcJ5Y5jQ=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "selectize": {
       "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/selectize/-/selectize-0.12.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/selectize/-/selectize-0.12.1.tgz",
       "integrity": "sha1-XoiqmpX4X/GW/ObaF/f2OhbWRMY=",
       "requires": {
         "microplugin": "0.0.3",
@@ -2012,18 +2012,18 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
     "sifter": {
       "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/sifter/-/sifter-0.4.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sifter/-/sifter-0.4.5.tgz",
       "integrity": "sha1-2ir236tB1v4UmrWzfuz7C1/RuYc=",
       "requires": {
         "async": "0.2.x",
@@ -2036,20 +2036,20 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         }
       }
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "source-map": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
         "amdefine": ">=0.0.4"
@@ -2057,18 +2057,18 @@
     },
     "spin.js": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/spin.js/-/spin.js-2.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/spin.js/-/spin.js-2.0.1.tgz",
       "integrity": "sha1-GhWKmsCTBgTT+flyZuiztlGcVp8="
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
@@ -2077,7 +2077,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -2086,13 +2086,13 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
@@ -2103,29 +2103,29 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/through/-/through-2.3.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "ticky": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ticky/-/ticky-1.0.0.tgz",
       "integrity": "sha1-6H847gSR6jL2Lo8FZ7qWOLKfBJw="
     },
     "titatoggle": {
       "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/titatoggle/-/titatoggle-1.2.15.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/titatoggle/-/titatoggle-1.2.15.tgz",
       "integrity": "sha1-0cuQVLLWGNsrHjUMXuBbPxh+v3I="
     },
     "to-double-quotes": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
       "integrity": "sha1-u27TbHhjTD1k/YelGtWGDcWU7f0=",
       "dev": true,
       "requires": {
@@ -2134,7 +2134,7 @@
     },
     "to-single-quotes": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
       "integrity": "sha1-LuqBma8myhFx9TV8WeGS1WXuUxM=",
       "dev": true,
       "requires": {
@@ -2143,18 +2143,18 @@
     },
     "tsscmp": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "type": {
       "version": "1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type/-/type-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type/-/type-1.2.0.tgz",
       "integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A=",
       "dev": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -2163,18 +2163,18 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
       "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
       "requires": {
@@ -2185,7 +2185,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "optional": true
         }
@@ -2193,70 +2193,70 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
     "underscore": {
       "version": "1.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore/-/underscore-1.7.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
     },
     "underscore.string": {
       "version": "2.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
     },
     "user-home": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "whatwg-fetch": {
       "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
       "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "which": {
       "version": "1.0.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/which/-/which-1.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/which/-/which-1.0.9.tgz",
       "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
       "dev": true
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "wrench": {
       "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wrench/-/wrench-1.5.9.tgz",
       "integrity": "sha1-QRaRxjqbJTGxcAJnJ5veyiOyFCo=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/write/-/write-0.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
@@ -2265,24 +2265,24 @@
     },
     "xdate": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/xdate/-/xdate-0.8.2.tgz",
       "integrity": "sha1-17AzwASF0CaVuvAET06s2j/JYaM="
     },
     "xml-escape": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/xml-escape/-/xml-escape-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/xml-escape/-/xml-escape-1.0.0.tgz",
       "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "optional": true,
       "requires": {

--- a/forgerock-ui-commons/src/main/assembly/zip.xml
+++ b/forgerock-ui-commons/src/main/assembly/zip.xml
@@ -40,7 +40,7 @@
             <outputDirectory>/</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>${basedir}/dist</directory>
+            <directory>${basedir}/target/frontend-libs</directory>
             <outputDirectory>/</outputDirectory>
             <fileMode>0640</fileMode>
         </fileSet>

--- a/forgerock-ui-mock/.npmrc
+++ b/forgerock-ui-mock/.npmrc
@@ -1,0 +1,1 @@
+registry = https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/

--- a/forgerock-ui-mock/package-lock.json
+++ b/forgerock-ui-mock/package-lock.json
@@ -5,14 +5,14 @@
   "dependencies": {
     "@types/node": {
       "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/@types/node/-/node-15.6.1.tgz",
       "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
       "dev": true,
       "optional": true
     },
     "@types/yauzl": {
       "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/@types/yauzl/-/yauzl-2.9.1.tgz",
       "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
       "dev": true,
       "optional": true,
@@ -22,19 +22,19 @@
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "agent-base": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/agent-base/-/agent-base-5.1.1.tgz",
       "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
       "dev": true
     },
     "ajv": {
       "version": "6.12.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ajv/-/ajv-6.12.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
       "dev": true,
       "optional": true,
@@ -47,25 +47,25 @@
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
@@ -74,14 +74,14 @@
     },
     "asap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/asap/-/asap-1.0.0.tgz",
       "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0=",
       "dev": true,
       "optional": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "optional": true,
@@ -91,58 +91,58 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true,
       "optional": true
     },
     "async": {
       "version": "0.1.22",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/async/-/async-0.1.22.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/async/-/async-0.1.22.tgz",
       "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true,
       "optional": true
     },
     "available-typed-arrays": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
       "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true,
       "optional": true
     },
     "aws4": {
       "version": "1.11.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/aws4/-/aws4-1.11.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk=",
       "dev": true,
       "optional": true
     },
     "balanced-match": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
@@ -152,7 +152,7 @@
     },
     "bl": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
       "requires": {
@@ -163,7 +163,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -176,7 +176,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
@@ -186,7 +186,7 @@
     },
     "buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "requires": {
@@ -196,19 +196,19 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "call-bind": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "requires": {
         "function-bind": "^1.1.1",
@@ -217,14 +217,14 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true,
       "optional": true
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -237,19 +237,19 @@
     },
     "chownr": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/circular-json/-/circular-json-0.3.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "clean-css": {
       "version": "3.4.28",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/clean-css/-/clean-css-3.4.28.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/clean-css/-/clean-css-3.4.28.tgz",
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "dev": true,
       "requires": {
@@ -259,7 +259,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -268,7 +268,7 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -279,30 +279,30 @@
     },
     "cli-width": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cli-width/-/cli-width-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/cli-width/-/cli-width-1.1.1.tgz",
       "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
       "dev": true
     },
     "codemirror": {
       "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-4.10.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/codemirror/-/codemirror-4.10.0.tgz",
       "integrity": "sha1-fUSw5AwhFbgCezUM7Xy4P8syzZs="
     },
     "coffee-script": {
       "version": "1.3.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/coffee-script/-/coffee-script-1.3.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/coffee-script/-/coffee-script-1.3.3.tgz",
       "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
       "dev": true
     },
     "colors": {
       "version": "0.6.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/colors/-/colors-0.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "optional": true,
@@ -312,18 +312,18 @@
     },
     "commander": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/commander/-/commander-7.1.0.tgz",
       "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg=="
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
@@ -335,13 +335,13 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "d": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/d/-/d-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/d/-/d-1.0.1.tgz",
       "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
       "dev": true,
       "requires": {
@@ -351,7 +351,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "optional": true,
@@ -361,13 +361,13 @@
     },
     "dateformat": {
       "version": "1.0.2-1.2.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
       "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
       "dev": true
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "requires": {
@@ -376,13 +376,13 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
         "object-keys": "^1.0.12"
@@ -390,14 +390,14 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true,
       "optional": true
     },
     "doctrine": {
       "version": "0.7.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/doctrine/-/doctrine-0.7.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/doctrine/-/doctrine-0.7.2.tgz",
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
@@ -407,7 +407,7 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
@@ -415,7 +415,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "optional": true,
@@ -426,7 +426,7 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
@@ -435,7 +435,7 @@
     },
     "errno": {
       "version": "0.1.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/errno/-/errno-0.1.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/errno/-/errno-0.1.8.tgz",
       "integrity": "sha1-i7Ppx9Rjvkl2/4iPdrSAnrwugR8=",
       "dev": true,
       "optional": true,
@@ -445,7 +445,7 @@
     },
     "es-abstract": {
       "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es-abstract/-/es-abstract-1.18.3.tgz",
       "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
       "requires": {
         "call-bind": "^1.0.2",
@@ -468,7 +468,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "requires": {
         "is-callable": "^1.1.4",
@@ -478,7 +478,7 @@
     },
     "es5-ext": {
       "version": "0.10.53",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.53.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
       "dev": true,
       "requires": {
@@ -489,7 +489,7 @@
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
@@ -500,7 +500,7 @@
     },
     "es6-map": {
       "version": "0.1.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-map/-/es6-map-0.1.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
@@ -514,7 +514,7 @@
     },
     "es6-set": {
       "version": "0.1.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-set/-/es6-set-0.1.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
@@ -527,7 +527,7 @@
       "dependencies": {
         "es6-symbol": {
           "version": "3.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "dev": true,
           "requires": {
@@ -539,7 +539,7 @@
     },
     "es6-symbol": {
       "version": "3.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
       "dev": true,
       "requires": {
@@ -549,7 +549,7 @@
     },
     "es6-weak-map": {
       "version": "2.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha1-ttofFswswNm+Q+a9v8Xn383zHVM=",
       "dev": true,
       "requires": {
@@ -561,13 +561,13 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
@@ -579,7 +579,7 @@
     },
     "eslint": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint/-/eslint-1.5.1.tgz",
       "integrity": "sha1-u54WHwFh1xuF3EgWO/FKhvICVis=",
       "dev": true,
       "requires": {
@@ -620,13 +620,13 @@
     },
     "eslint-config-forgerock": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-forgerock/-/eslint-config-forgerock-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint-config-forgerock/-/eslint-config-forgerock-1.0.0.tgz",
       "integrity": "sha1-hhQV5Y2lq3yGBdAXasgTVEKo2Mc=",
       "dev": true
     },
     "eslint-formatter-warning-summary": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-warning-summary/-/eslint-formatter-warning-summary-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint-formatter-warning-summary/-/eslint-formatter-warning-summary-1.0.1.tgz",
       "integrity": "sha1-6Xe7j+srOgl44Ue5WziXp29TZHs=",
       "dev": true,
       "requires": {
@@ -636,13 +636,13 @@
     },
     "espree": {
       "version": "2.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz",
       "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
       "dev": true
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "requires": {
@@ -651,7 +651,7 @@
       "dependencies": {
         "estraverse": {
           "version": "5.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse/-/estraverse-5.2.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
           "dev": true
         }
@@ -659,25 +659,25 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "estraverse-fb": {
       "version": "1.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
       "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
       "dev": true
     },
     "esutils": {
       "version": "1.1.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz",
       "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
@@ -687,19 +687,19 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "ext": {
       "version": "1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ext/-/ext-1.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ext/-/ext-1.4.0.tgz",
       "integrity": "sha1-ia56BxWPedNVF4gpBDJAd+Q3kkQ=",
       "dev": true,
       "requires": {
@@ -708,7 +708,7 @@
       "dependencies": {
         "type": {
           "version": "2.5.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type/-/type-2.5.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type/-/type-2.5.0.tgz",
           "integrity": "sha1-Ci54wud5B7JSq+XymMGwHGPw2z0=",
           "dev": true
         }
@@ -716,14 +716,14 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true,
       "optional": true
     },
     "extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "requires": {
@@ -735,7 +735,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
@@ -744,7 +744,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -752,40 +752,40 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true,
       "optional": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "optional": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true,
       "optional": true
     },
     "fast-levenshtein": {
       "version": "1.0.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
       "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
       "dev": true
     },
     "faye-websocket": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/faye-websocket/-/faye-websocket-0.4.4.tgz",
       "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w=",
       "dev": true
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
@@ -794,7 +794,7 @@
     },
     "figures": {
       "version": "1.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/figures/-/figures-1.7.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
@@ -804,7 +804,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
@@ -812,7 +812,7 @@
     },
     "file-entry-cache": {
       "version": "1.3.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
@@ -822,7 +822,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
@@ -830,13 +830,13 @@
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
       "dev": true
     },
     "findup-sync": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/findup-sync/-/findup-sync-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/findup-sync/-/findup-sync-0.1.3.tgz",
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
@@ -846,7 +846,7 @@
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -856,13 +856,13 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -874,7 +874,7 @@
     },
     "flat-cache": {
       "version": "1.3.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/flat-cache/-/flat-cache-1.3.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha1-LC73dSXMKSkAff/6HdMUqpyd7m8=",
       "dev": true,
       "requires": {
@@ -886,19 +886,19 @@
     },
     "foreach": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true,
       "optional": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "optional": true,
@@ -910,7 +910,7 @@
     },
     "formatio": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "requires": {
         "samsam": "~1.1"
@@ -918,13 +918,13 @@
     },
     "fs-constants": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
     "fs-extra": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fs-extra/-/fs-extra-6.0.1.tgz",
       "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
       "dev": true,
       "requires": {
@@ -935,18 +935,18 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gaze": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
@@ -955,7 +955,7 @@
     },
     "generate-function": {
       "version": "2.3.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/generate-function/-/generate-function-2.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
       "dev": true,
       "requires": {
@@ -964,7 +964,7 @@
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
@@ -973,7 +973,7 @@
     },
     "get-intrinsic": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "requires": {
         "function-bind": "^1.1.1",
@@ -983,13 +983,13 @@
     },
     "get-stdin": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/get-stdin/-/get-stdin-3.0.2.tgz",
       "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4=",
       "dev": true
     },
     "get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "requires": {
@@ -998,13 +998,13 @@
     },
     "getobject": {
       "version": "0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/getobject/-/getobject-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "optional": true,
@@ -1014,7 +1014,7 @@
     },
     "glob": {
       "version": "5.0.15",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
@@ -1027,23 +1027,23 @@
     },
     "globals": {
       "version": "8.18.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz",
       "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
       "dev": true
     },
     "globalyzer": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/globalyzer/-/globalyzer-0.1.0.tgz",
       "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
     },
     "globrex": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "globule": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
@@ -1054,7 +1054,7 @@
       "dependencies": {
         "glob": {
           "version": "3.1.21",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.1.21.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
@@ -1065,25 +1065,25 @@
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "inherits": {
           "version": "1.0.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inherits/-/inherits-1.0.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
         "lodash": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-1.0.2.tgz",
           "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
@@ -1095,19 +1095,19 @@
     },
     "graceful-fs": {
       "version": "4.2.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
       "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "grunt": {
       "version": "0.4.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt/-/grunt-0.4.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
@@ -1135,7 +1135,7 @@
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/argparse/-/argparse-0.1.16.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
@@ -1145,7 +1145,7 @@
           "dependencies": {
             "underscore.string": {
               "version": "2.4.0",
-              "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.4.0.tgz",
+              "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.4.0.tgz",
               "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
               "dev": true
             }
@@ -1153,13 +1153,13 @@
         },
         "esprima": {
           "version": "1.0.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         },
         "glob": {
           "version": "3.1.21",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.1.21.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
@@ -1170,19 +1170,19 @@
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "inherits": {
           "version": "1.0.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inherits/-/inherits-1.0.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
         "js-yaml": {
           "version": "2.0.5",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/js-yaml/-/js-yaml-2.0.5.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-2.0.5.tgz",
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
@@ -1192,13 +1192,13 @@
         },
         "lodash": {
           "version": "0.9.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
@@ -1208,7 +1208,7 @@
         },
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -1216,7 +1216,7 @@
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
       "dev": true,
       "requires": {
@@ -1227,7 +1227,7 @@
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
@@ -1237,7 +1237,7 @@
     },
     "grunt-contrib-less": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-less/-/grunt-contrib-less-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-contrib-less/-/grunt-contrib-less-1.0.1.tgz",
       "integrity": "sha1-h/MqXkdJh6QFycmJDTNoakUCHVE=",
       "dev": true,
       "requires": {
@@ -1249,25 +1249,25 @@
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
           "dev": true
         },
         "ansi-styles": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-styles/-/ansi-styles-1.1.0.tgz",
           "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
           "dev": true
         },
         "async": {
           "version": "0.9.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/async/-/async-0.9.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
@@ -1280,7 +1280,7 @@
         },
         "has-ansi": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
@@ -1289,13 +1289,13 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
@@ -1304,7 +1304,7 @@
         },
         "supports-color": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-0.2.0.tgz",
           "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
           "dev": true
         }
@@ -1312,7 +1312,7 @@
     },
     "grunt-contrib-qunit": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-qunit/-/grunt-contrib-qunit-4.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-contrib-qunit/-/grunt-contrib-qunit-4.0.0.tgz",
       "integrity": "sha512-XP9Ks+uoSQzic0eic6koD8kYAKQnSYfu2G1HBqvrvUyXaDDnSSXOKELND8j7dwudnJj4N6KgW6OU7AHeM5PGKA==",
       "dev": true,
       "requires": {
@@ -1323,7 +1323,7 @@
       "dependencies": {
         "eventemitter2": {
           "version": "6.4.4",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eventemitter2/-/eventemitter2-6.4.4.tgz",
           "integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
           "dev": true
         }
@@ -1331,7 +1331,7 @@
     },
     "grunt-contrib-requirejs": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
       "integrity": "sha1-h/IWWpgeSKRdIvjMUpnQk0AxuXI=",
       "dev": true,
       "requires": {
@@ -1340,7 +1340,7 @@
     },
     "grunt-contrib-watch": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
       "integrity": "sha1-ZP3LolpjX1tNobbOb5DaCutuPxU=",
       "dev": true,
       "requires": {
@@ -1352,13 +1352,13 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         }
@@ -1366,7 +1366,7 @@
     },
     "grunt-eslint": {
       "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-eslint/-/grunt-eslint-17.3.1.tgz",
       "integrity": "sha1-w7UOENnF9dc9g/RnePgDb4SpY60=",
       "dev": true,
       "requires": {
@@ -1376,7 +1376,7 @@
     },
     "grunt-legacy-log": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
       "requires": {
@@ -1389,13 +1389,13 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -1403,7 +1403,7 @@
     },
     "grunt-legacy-log-utils": {
       "version": "0.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
       "requires": {
@@ -1414,13 +1414,13 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -1428,7 +1428,7 @@
     },
     "grunt-legacy-util": {
       "version": "0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
       "requires": {
@@ -1443,7 +1443,7 @@
       "dependencies": {
         "lodash": {
           "version": "0.9.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         }
@@ -1451,7 +1451,7 @@
     },
     "grunt-notify": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/grunt-notify/-/grunt-notify-0.4.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-notify/-/grunt-notify-0.4.3.tgz",
       "integrity": "sha1-dmV75M71M3wgYcmZvRoPUMtmCCA=",
       "dev": true,
       "requires": {
@@ -1462,13 +1462,13 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/semver/-/semver-5.7.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/semver/-/semver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         },
         "which": {
           "version": "1.3.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/which/-/which-1.3.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/which/-/which-1.3.1.tgz",
           "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
           "dev": true,
           "requires": {
@@ -1479,7 +1479,7 @@
     },
     "grunt-sync": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/grunt-sync/-/grunt-sync-0.8.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-sync/-/grunt-sync-0.8.2.tgz",
       "integrity": "sha512-PB+xKI9YPyZn3NZQXpKHfZVlxHdf1L8GMl+Wi0mLhYypWuOdZPW2EzTmSuhhFbXjkb0aIOxvII1zdZZEl9zqGg==",
       "dev": true,
       "requires": {
@@ -1490,7 +1490,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.7.tgz",
           "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "dev": true,
           "requires": {
@@ -1504,7 +1504,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -1515,7 +1515,7 @@
     },
     "handlebars": {
       "version": "4.7.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/handlebars/-/handlebars-4.7.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha1-nOM0FqrQLb1sj6+oJA1dmABJRaE=",
       "dev": true,
       "requires": {
@@ -1528,14 +1528,14 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true,
       "optional": true
     },
     "har-validator": {
       "version": "5.1.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/har-validator/-/har-validator-5.1.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
       "dev": true,
       "optional": true,
@@ -1546,7 +1546,7 @@
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
@@ -1554,7 +1554,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -1563,23 +1563,23 @@
     },
     "has-bigints": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
     "has-symbols": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "hooker": {
       "version": "0.2.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/hooker/-/hooker-0.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "optional": true,
@@ -1591,7 +1591,7 @@
     },
     "https-proxy-agent": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
       "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
       "dev": true,
       "requires": {
@@ -1601,7 +1601,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
@@ -1610,7 +1610,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
@@ -1618,26 +1618,26 @@
     },
     "iconv-lite": {
       "version": "0.2.11",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.2.11.tgz",
       "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
       "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "image-size": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/image-size/-/image-size-0.3.5.tgz",
       "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw=",
       "dev": true,
       "optional": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -1647,12 +1647,12 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "inquirer": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inquirer/-/inquirer-0.9.0.tgz",
       "integrity": "sha1-c2bjijMeYZBJWKzlstpKml9jZ5g=",
       "dev": true,
       "requires": {
@@ -1670,7 +1670,7 @@
     },
     "is-arguments": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-arguments/-/is-arguments-1.1.0.tgz",
       "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
       "requires": {
         "call-bind": "^1.0.0"
@@ -1678,12 +1678,12 @@
     },
     "is-bigint": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-bigint/-/is-bigint-1.0.2.tgz",
       "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
     },
     "is-boolean-object": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
       "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
       "requires": {
         "call-bind": "^1.0.2"
@@ -1691,28 +1691,28 @@
     },
     "is-callable": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-callable/-/is-callable-1.2.3.tgz",
       "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
     },
     "is-date-object": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-date-object/-/is-date-object-1.0.4.tgz",
       "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
     },
     "is-generator-function": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-generator-function/-/is-generator-function-1.0.9.tgz",
       "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A=="
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
       "dev": true
     },
     "is-my-json-valid": {
       "version": "2.20.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
       "integrity": "sha1-XspqgjKmh/aIabc2G+FhLnUS5d8=",
       "dev": true,
       "requires": {
@@ -1725,23 +1725,23 @@
     },
     "is-negative-zero": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
       "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
     },
     "is-number-object": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-number-object/-/is-number-object-1.0.5.tgz",
       "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-regex": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-regex/-/is-regex-1.1.3.tgz",
       "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
       "requires": {
         "call-bind": "^1.0.2",
@@ -1750,18 +1750,18 @@
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "is-string": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-string/-/is-string-1.0.6.tgz",
       "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
     },
     "is-symbol": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
       "requires": {
         "has-symbols": "^1.0.2"
@@ -1769,7 +1769,7 @@
     },
     "is-typed-array": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-typed-array/-/is-typed-array-1.1.5.tgz",
       "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
       "requires": {
         "available-typed-arrays": "^1.0.2",
@@ -1781,38 +1781,38 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true,
       "optional": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true,
       "optional": true
     },
     "js-reporters": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js-reporters/-/js-reporters-2.0.0.tgz",
       "integrity": "sha512-VJd/86niT7GzsaVc+Yxrs8QPrYl1orzv8bYZPuSOtxU6rk/pv8aOXTcIa7HaANvtvdLMTsZspAiucNQ6T2QFHw=="
     },
     "js-yaml": {
       "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
       "dev": true,
       "requires": {
@@ -1822,7 +1822,7 @@
       "dependencies": {
         "esprima": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esprima/-/esprima-4.0.1.tgz",
           "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
           "dev": true
         }
@@ -1830,35 +1830,35 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true,
       "optional": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true,
       "optional": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true,
       "optional": true
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
@@ -1867,13 +1867,13 @@
     },
     "jsonpointer": {
       "version": "4.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/jsonpointer/-/jsonpointer-4.1.0.tgz",
       "integrity": "sha1-UB+4mYaiOJdlugnmBTKZzrTywsw=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "optional": true,
@@ -1886,7 +1886,7 @@
     },
     "less": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/less/-/less-2.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/less/-/less-2.4.0.tgz",
       "integrity": "sha1-zlGzjxwFoM3UeYL6xA3Qo5zsIDE=",
       "dev": true,
       "requires": {
@@ -1902,7 +1902,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.12",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-3.0.12.tgz",
           "integrity": "sha1-ADSUfOntaV7IqwuFS8kZ6Csf+u8=",
           "dev": true,
           "optional": true,
@@ -1912,7 +1912,7 @@
         },
         "source-map": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
           "optional": true,
@@ -1924,7 +1924,7 @@
     },
     "less-plugin-clean-css": {
       "version": "1.5.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/less-plugin-clean-css/-/less-plugin-clean-css-1.5.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/less-plugin-clean-css/-/less-plugin-clean-css-1.5.1.tgz",
       "integrity": "sha1-zFeveqM5iVflbezr5jy2DCNClwM=",
       "dev": true,
       "requires": {
@@ -1933,7 +1933,7 @@
     },
     "levn": {
       "version": "0.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/levn/-/levn-0.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/levn/-/levn-0.2.5.tgz",
       "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
       "dev": true,
       "requires": {
@@ -1943,31 +1943,31 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-3.10.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
       "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
       "dev": true
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
       "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
       "dev": true
     },
     "lodash._arraymap": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
       "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
@@ -1977,7 +1977,7 @@
     },
     "lodash._baseclone": {
       "version": "3.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "dev": true,
       "requires": {
@@ -1991,13 +1991,13 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basedifference": {
       "version": "3.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
       "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
       "dev": true,
       "requires": {
@@ -2008,7 +2008,7 @@
     },
     "lodash._baseflatten": {
       "version": "3.1.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
       "dev": true,
       "requires": {
@@ -2018,31 +2018,31 @@
     },
     "lodash._basefor": {
       "version": "3.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
       "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
       "dev": true
     },
     "lodash._baseindexof": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
       "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
       "dev": true
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "dev": true
     },
     "lodash._cacheindexof": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
       "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
       "dev": true
     },
     "lodash._createassigner": {
       "version": "3.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
@@ -2053,7 +2053,7 @@
     },
     "lodash._createcache": {
       "version": "3.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
       "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
       "dev": true,
       "requires": {
@@ -2062,25 +2062,25 @@
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash._pickbyarray": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
       "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
       "dev": true
     },
     "lodash._pickbycallback": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
       "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
       "dev": true,
       "requires": {
@@ -2090,7 +2090,7 @@
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
       "dev": true,
       "requires": {
@@ -2100,19 +2100,19 @@
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "3.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
       "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
       "dev": true,
       "requires": {
@@ -2123,13 +2123,13 @@
     },
     "lodash.istypedarray": {
       "version": "3.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
       "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -2140,7 +2140,7 @@
     },
     "lodash.keysin": {
       "version": "3.0.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
       "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
       "dev": true,
       "requires": {
@@ -2150,7 +2150,7 @@
     },
     "lodash.merge": {
       "version": "3.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.merge/-/lodash.merge-3.3.2.tgz",
       "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
       "dev": true,
       "requires": {
@@ -2169,7 +2169,7 @@
     },
     "lodash.omit": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.omit/-/lodash.omit-3.1.0.tgz",
       "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
       "dev": true,
       "requires": {
@@ -2185,13 +2185,13 @@
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
       "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
       "dev": true,
       "requires": {
@@ -2201,38 +2201,38 @@
     },
     "lolex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lolex/-/lolex-1.1.0.tgz",
       "integrity": "sha1-Xbu8hQOV51I8dLNYb3+9JibSWxs="
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "md5-file": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-2.0.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/md5-file/-/md5-file-2.0.7.tgz",
       "integrity": "sha1-MH94vQTMsFTkZ+xmHPpamv3J8hA=",
       "dev": true
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mime/-/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "dev": true,
       "optional": true
     },
     "mime-db": {
       "version": "1.47.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mime-db/-/mime-db-1.47.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mime-db/-/mime-db-1.47.0.tgz",
       "integrity": "sha1-jLMT5Zll08Bc+/iYkVomevRqM1w=",
       "dev": true,
       "optional": true
     },
     "mime-types": {
       "version": "2.1.30",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mime-types/-/mime-types-2.1.30.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mime-types/-/mime-types-2.1.30.tgz",
       "integrity": "sha1-bnvotMR5gl+F7WMmaV23P5MF1i0=",
       "dev": true,
       "optional": true,
@@ -2242,7 +2242,7 @@
     },
     "minimatch": {
       "version": "2.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "dev": true,
       "requires": {
@@ -2251,19 +2251,19 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimist/-/minimist-1.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "mitt": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mitt/-/mitt-2.1.0.tgz",
       "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg==",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
@@ -2272,49 +2272,49 @@
     },
     "mkdirp-classic": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mute-stream/-/mute-stream-0.0.4.tgz",
       "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
       "dev": true
     },
     "natives": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/natives/-/natives-1.1.6.tgz",
       "integrity": "sha1-pgO0pJirdxc2ErnqGs3sTZgPALs=",
       "dev": true,
       "optional": true
     },
     "neo-async": {
       "version": "2.6.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/neo-async/-/neo-async-2.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "node-watch": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/node-watch/-/node-watch-0.7.1.tgz",
       "integrity": "sha512-UWblPYuZYrkCQCW5PxAwYSxaELNBLUckrTBBk8xr1/bUgyOkYYTsUcV4e3ytcazFEOyiRyiUrsG37pu6I0I05g=="
     },
     "nopt": {
       "version": "1.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/nopt/-/nopt-1.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
@@ -2323,7 +2323,7 @@
     },
     "noptify": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/noptify/-/noptify-0.0.3.tgz",
       "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
       "dev": true,
       "requires": {
@@ -2332,7 +2332,7 @@
       "dependencies": {
         "nopt": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/nopt/-/nopt-2.0.0.tgz",
           "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
           "dev": true,
           "requires": {
@@ -2343,30 +2343,30 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true,
       "optional": true
     },
     "object-assign": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-2.1.1.tgz",
       "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
       "dev": true
     },
     "object-inspect": {
       "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-inspect/-/object-inspect-1.10.3.tgz",
       "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "requires": {
         "call-bind": "^1.0.0",
@@ -2377,7 +2377,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -2386,7 +2386,7 @@
     },
     "optionator": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/optionator/-/optionator-0.5.0.tgz",
       "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
       "dev": true,
       "requires": {
@@ -2400,7 +2400,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -2408,56 +2408,56 @@
     },
     "p-each-series": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/p-each-series/-/p-each-series-2.2.0.tgz",
       "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true,
       "optional": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/promise/-/promise-6.1.0.tgz",
       "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
       "dev": true,
       "optional": true,
@@ -2467,27 +2467,27 @@
     },
     "proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true,
       "optional": true
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/psl/-/psl-1.8.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/psl/-/psl-1.8.0.tgz",
       "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
       "dev": true,
       "optional": true
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
@@ -2497,14 +2497,14 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true,
       "optional": true
     },
     "puppeteer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-4.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/puppeteer/-/puppeteer-4.0.1.tgz",
       "integrity": "sha512-LIiSWTRqpTnnm3R2yAoMBx1inSeKwVZy66RFSkgSTDINzheJZPd5z5mMbPM0FkvwWAZ27a+69j5nZf+Fpyhn3Q==",
       "dev": true,
       "requires": {
@@ -2523,7 +2523,7 @@
       "dependencies": {
         "debug": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
@@ -2532,7 +2532,7 @@
         },
         "glob": {
           "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.7.tgz",
           "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "dev": true,
           "requires": {
@@ -2546,13 +2546,13 @@
         },
         "mime": {
           "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mime/-/mime-2.5.2.tgz",
           "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
@@ -2561,13 +2561,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "rimraf": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
           "dev": true,
           "requires": {
@@ -2578,14 +2578,14 @@
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/qs/-/qs-6.5.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true,
       "optional": true
     },
     "qunit": {
       "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.15.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/qunit/-/qunit-2.15.0.tgz",
       "integrity": "sha512-9ZoOILeyRZzrdvy2m7M4S76bneGD75Bh4B2aot3uKRKZuoEvA9gevvzU339L805Ys0AN2C7cnAV9nIBD5t72IQ==",
       "requires": {
         "commander": "7.1.0",
@@ -2596,7 +2596,7 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "dev": true,
       "requires": {
@@ -2611,7 +2611,7 @@
     },
     "readline2": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/readline2/-/readline2-0.1.1.tgz",
       "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
       "dev": true,
       "requires": {
@@ -2621,13 +2621,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-1.1.1.tgz",
           "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
           "dev": true
         },
         "strip-ansi": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
           "dev": true,
           "requires": {
@@ -2638,7 +2638,7 @@
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/request/-/request-2.88.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/request/-/request-2.88.2.tgz",
       "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "dev": true,
       "optional": true,
@@ -2667,19 +2667,19 @@
     },
     "requirejs": {
       "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.22.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/requirejs/-/requirejs-2.1.22.tgz",
       "integrity": "sha1-3Xj9LTQYDA1ixyS1uK68BmTgNm8=",
       "dev": true
     },
     "resolve": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/resolve/-/resolve-0.3.1.tgz",
       "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
       "dev": true
     },
     "rimraf": {
       "version": "2.6.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rimraf/-/rimraf-2.6.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "dev": true,
       "requires": {
@@ -2688,7 +2688,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.7.tgz",
           "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
           "dev": true,
           "requires": {
@@ -2702,7 +2702,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
@@ -2713,7 +2713,7 @@
     },
     "run-async": {
       "version": "0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
@@ -2722,42 +2722,42 @@
     },
     "rx-lite": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rx-lite/-/rx-lite-2.5.2.tgz",
       "integrity": "sha1-X+9C1Nbna6tRmdIXEyfbcJ5Y5jQ=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true,
       "optional": true
     },
     "samsam": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "sinon": {
       "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.15.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sinon/-/sinon-1.15.4.tgz",
       "integrity": "sha1-AxXxdM5bMXkq6i46Kvxbt4BMemo=",
       "requires": {
         "formatio": "1.1.1",
@@ -2768,19 +2768,19 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "optional": true,
@@ -2798,13 +2798,13 @@
     },
     "stack-parser": {
       "version": "0.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/stack-parser/-/stack-parser-0.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/stack-parser/-/stack-parser-0.0.1.tgz",
       "integrity": "sha1-fTtjoXiH6eLCv1Xb0zGP40o50ec=",
       "dev": true
     },
     "string.prototype.trimend": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "requires": {
         "call-bind": "^1.0.2",
@@ -2813,7 +2813,7 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "requires": {
         "call-bind": "^1.0.2",
@@ -2822,7 +2822,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
@@ -2831,7 +2831,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -2840,19 +2840,19 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "tar-fs": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
       "requires": {
@@ -2864,7 +2864,7 @@
     },
     "tar-stream": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
       "requires": {
@@ -2877,7 +2877,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
@@ -2890,19 +2890,19 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/through/-/through-2.3.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "tiny-glob": {
       "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/tiny-glob/-/tiny-glob-0.2.8.tgz",
       "integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
       "requires": {
         "globalyzer": "0.1.0",
@@ -2911,7 +2911,7 @@
     },
     "tiny-lr-fork": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
       "integrity": "sha1-Hpnh4qhGm3NquX2X7vqYxx927Qo=",
       "dev": true,
       "requires": {
@@ -2923,13 +2923,13 @@
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/debug/-/debug-0.7.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
           "dev": true
         },
         "qs": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/qs/-/qs-0.5.6.tgz",
           "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
           "dev": true
         }
@@ -2937,7 +2937,7 @@
     },
     "to-double-quotes": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
       "integrity": "sha1-u27TbHhjTD1k/YelGtWGDcWU7f0=",
       "dev": true,
       "requires": {
@@ -2946,7 +2946,7 @@
     },
     "to-single-quotes": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
       "integrity": "sha1-LuqBma8myhFx9TV8WeGS1WXuUxM=",
       "dev": true,
       "requires": {
@@ -2955,7 +2955,7 @@
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "dev": true,
       "optional": true,
@@ -2966,7 +2966,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "optional": true,
@@ -2976,20 +2976,20 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type": {
       "version": "1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type/-/type-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type/-/type-1.2.0.tgz",
       "integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A=",
       "dev": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -2998,20 +2998,20 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.13.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/uglify-js/-/uglify-js-3.13.6.tgz",
       "integrity": "sha1-aBWsf90VXQPIPiNiu3F+Wzm3QBM=",
       "dev": true,
       "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
       "requires": {
         "function-bind": "^1.1.1",
@@ -3022,7 +3022,7 @@
     },
     "unbzip2-stream": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
       "requires": {
@@ -3032,25 +3032,25 @@
     },
     "underscore": {
       "version": "1.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore/-/underscore-1.7.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
     "underscore.string": {
       "version": "2.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
     },
     "universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "uri-js": {
       "version": "4.4.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/uri-js/-/uri-js-4.4.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
       "dev": true,
       "optional": true,
@@ -3060,13 +3060,13 @@
     },
     "user-home": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "util": {
       "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/util/-/util-0.12.3.tgz",
       "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
       "requires": {
         "inherits": "^2.0.3",
@@ -3079,20 +3079,20 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {
       "version": "3.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/uuid/-/uuid-3.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
       "dev": true,
       "optional": true
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "optional": true,
@@ -3104,13 +3104,13 @@
     },
     "which": {
       "version": "1.0.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/which/-/which-1.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/which/-/which-1.0.9.tgz",
       "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
       "dev": true
     },
     "which-boxed-primitive": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
       "requires": {
         "is-bigint": "^1.0.1",
@@ -3122,7 +3122,7 @@
     },
     "which-typed-array": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/which-typed-array/-/which-typed-array-1.1.4.tgz",
       "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
       "requires": {
         "available-typed-arrays": "^1.0.2",
@@ -3136,19 +3136,19 @@
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/write/-/write-0.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
@@ -3157,25 +3157,25 @@
     },
     "ws": {
       "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true
     },
     "xml-escape": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/xml-escape/-/xml-escape-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/xml-escape/-/xml-escape-1.0.0.tgz",
       "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {

--- a/forgerock-ui-user/.npmrc
+++ b/forgerock-ui-user/.npmrc
@@ -1,0 +1,1 @@
+registry = https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/

--- a/forgerock-ui-user/package-lock.json
+++ b/forgerock-ui-user/package-lock.json
@@ -5,25 +5,25 @@
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
@@ -32,19 +32,19 @@
     },
     "async": {
       "version": "0.1.22",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/async/-/async-0.1.22.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/async/-/async-0.1.22.tgz",
       "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
@@ -54,13 +54,13 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -73,37 +73,37 @@
     },
     "circular-json": {
       "version": "0.3.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/circular-json/-/circular-json-0.3.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-width": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cli-width/-/cli-width-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/cli-width/-/cli-width-1.1.1.tgz",
       "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
       "dev": true
     },
     "coffee-script": {
       "version": "1.3.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/coffee-script/-/coffee-script-1.3.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/coffee-script/-/coffee-script-1.3.3.tgz",
       "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
       "dev": true
     },
     "colors": {
       "version": "0.6.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/colors/-/colors-0.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
@@ -115,13 +115,13 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "d": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/d/-/d-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/d/-/d-1.0.1.tgz",
       "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
       "dev": true,
       "requires": {
@@ -131,13 +131,13 @@
     },
     "dateformat": {
       "version": "1.0.2-1.2.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
       "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
       "dev": true
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "requires": {
@@ -146,13 +146,13 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "doctrine": {
       "version": "0.7.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/doctrine/-/doctrine-0.7.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/doctrine/-/doctrine-0.7.2.tgz",
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
@@ -162,7 +162,7 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         }
@@ -170,7 +170,7 @@
     },
     "es5-ext": {
       "version": "0.10.53",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.53.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
       "dev": true,
       "requires": {
@@ -181,7 +181,7 @@
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
@@ -192,7 +192,7 @@
     },
     "es6-map": {
       "version": "0.1.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-map/-/es6-map-0.1.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
@@ -206,7 +206,7 @@
     },
     "es6-set": {
       "version": "0.1.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-set/-/es6-set-0.1.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
@@ -219,7 +219,7 @@
       "dependencies": {
         "es6-symbol": {
           "version": "3.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "dev": true,
           "requires": {
@@ -231,7 +231,7 @@
     },
     "es6-symbol": {
       "version": "3.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
       "dev": true,
       "requires": {
@@ -241,7 +241,7 @@
     },
     "es6-weak-map": {
       "version": "2.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha1-ttofFswswNm+Q+a9v8Xn383zHVM=",
       "dev": true,
       "requires": {
@@ -253,13 +253,13 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escope": {
       "version": "3.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
@@ -271,7 +271,7 @@
     },
     "eslint": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.5.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint/-/eslint-1.5.1.tgz",
       "integrity": "sha1-u54WHwFh1xuF3EgWO/FKhvICVis=",
       "dev": true,
       "requires": {
@@ -312,13 +312,13 @@
     },
     "eslint-config-forgerock": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-forgerock/-/eslint-config-forgerock-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint-config-forgerock/-/eslint-config-forgerock-1.0.0.tgz",
       "integrity": "sha1-hhQV5Y2lq3yGBdAXasgTVEKo2Mc=",
       "dev": true
     },
     "eslint-formatter-warning-summary": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-warning-summary/-/eslint-formatter-warning-summary-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eslint-formatter-warning-summary/-/eslint-formatter-warning-summary-1.0.1.tgz",
       "integrity": "sha1-6Xe7j+srOgl44Ue5WziXp29TZHs=",
       "dev": true,
       "requires": {
@@ -328,13 +328,13 @@
     },
     "espree": {
       "version": "2.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz",
       "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
       "dev": true
     },
     "esrecurse": {
       "version": "4.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "requires": {
@@ -343,7 +343,7 @@
       "dependencies": {
         "estraverse": {
           "version": "5.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse/-/estraverse-5.2.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
           "dev": true
         }
@@ -351,25 +351,25 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "estraverse-fb": {
       "version": "1.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
       "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
       "dev": true
     },
     "esutils": {
       "version": "1.1.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz",
       "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
@@ -379,19 +379,19 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "ext": {
       "version": "1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ext/-/ext-1.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ext/-/ext-1.4.0.tgz",
       "integrity": "sha1-ia56BxWPedNVF4gpBDJAd+Q3kkQ=",
       "dev": true,
       "requires": {
@@ -400,7 +400,7 @@
       "dependencies": {
         "type": {
           "version": "2.5.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type/-/type-2.5.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type/-/type-2.5.0.tgz",
           "integrity": "sha1-Ci54wud5B7JSq+XymMGwHGPw2z0=",
           "dev": true
         }
@@ -408,13 +408,13 @@
     },
     "fast-levenshtein": {
       "version": "1.0.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
       "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
       "dev": true
     },
     "figures": {
       "version": "1.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/figures/-/figures-1.7.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
@@ -424,7 +424,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
@@ -432,7 +432,7 @@
     },
     "file-entry-cache": {
       "version": "1.3.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
@@ -442,7 +442,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
@@ -450,7 +450,7 @@
     },
     "findup-sync": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/findup-sync/-/findup-sync-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/findup-sync/-/findup-sync-0.1.3.tgz",
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
@@ -460,7 +460,7 @@
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
@@ -470,13 +470,13 @@
         },
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "minimatch": {
           "version": "0.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
@@ -488,7 +488,7 @@
     },
     "flat-cache": {
       "version": "1.3.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/flat-cache/-/flat-cache-1.3.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha1-LC73dSXMKSkAff/6HdMUqpyd7m8=",
       "dev": true,
       "requires": {
@@ -500,13 +500,13 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "generate-function": {
       "version": "2.3.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/generate-function/-/generate-function-2.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
       "dev": true,
       "requires": {
@@ -515,7 +515,7 @@
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
@@ -524,19 +524,19 @@
     },
     "get-stdin": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/get-stdin/-/get-stdin-3.0.2.tgz",
       "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4=",
       "dev": true
     },
     "getobject": {
       "version": "0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/getobject/-/getobject-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
     "glob": {
       "version": "5.0.15",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
@@ -549,19 +549,19 @@
     },
     "globals": {
       "version": "8.18.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz",
       "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
       "dev": true
     },
     "graceful-fs": {
       "version": "4.2.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha1-/wQLKwhTsjw9MQJ1I3BvGIXXa+4=",
       "dev": true
     },
     "grunt": {
       "version": "0.4.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt/-/grunt-0.4.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt/-/grunt-0.4.5.tgz",
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
@@ -589,7 +589,7 @@
       "dependencies": {
         "argparse": {
           "version": "0.1.16",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/argparse/-/argparse-0.1.16.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/argparse/-/argparse-0.1.16.tgz",
           "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
           "dev": true,
           "requires": {
@@ -599,7 +599,7 @@
           "dependencies": {
             "underscore.string": {
               "version": "2.4.0",
-              "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.4.0.tgz",
+              "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.4.0.tgz",
               "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
               "dev": true
             }
@@ -607,13 +607,13 @@
         },
         "esprima": {
           "version": "1.0.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esprima/-/esprima-1.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esprima/-/esprima-1.0.4.tgz",
           "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
           "dev": true
         },
         "glob": {
           "version": "3.1.21",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.1.21.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
@@ -624,19 +624,19 @@
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
           "dev": true
         },
         "inherits": {
           "version": "1.0.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inherits/-/inherits-1.0.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inherits/-/inherits-1.0.2.tgz",
           "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
           "dev": true
         },
         "js-yaml": {
           "version": "2.0.5",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/js-yaml/-/js-yaml-2.0.5.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-2.0.5.tgz",
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
@@ -646,13 +646,13 @@
         },
         "lodash": {
           "version": "0.9.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
           "dev": true,
           "requires": {
@@ -662,7 +662,7 @@
         },
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -670,7 +670,7 @@
     },
     "grunt-cli": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-cli/-/grunt-cli-0.1.13.tgz",
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
       "dev": true,
       "requires": {
@@ -681,7 +681,7 @@
     },
     "grunt-eslint": {
       "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-eslint/-/grunt-eslint-17.3.1.tgz",
       "integrity": "sha1-w7UOENnF9dc9g/RnePgDb4SpY60=",
       "dev": true,
       "requires": {
@@ -691,7 +691,7 @@
     },
     "grunt-legacy-log": {
       "version": "0.1.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-log/-/grunt-legacy-log-0.1.3.tgz",
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
       "requires": {
@@ -704,13 +704,13 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -718,7 +718,7 @@
     },
     "grunt-legacy-log-utils": {
       "version": "0.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
       "requires": {
@@ -729,13 +729,13 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.3.3.tgz",
           "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
           "dev": true
         }
@@ -743,7 +743,7 @@
     },
     "grunt-legacy-util": {
       "version": "0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz",
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
       "requires": {
@@ -758,7 +758,7 @@
       "dependencies": {
         "lodash": {
           "version": "0.9.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-0.9.2.tgz",
           "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
           "dev": true
         }
@@ -766,7 +766,7 @@
     },
     "handlebars": {
       "version": "4.7.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/handlebars/-/handlebars-4.7.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/handlebars/-/handlebars-4.7.7.tgz",
       "integrity": "sha1-nOM0FqrQLb1sj6+oJA1dmABJRaE=",
       "dev": true,
       "requires": {
@@ -779,7 +779,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -788,19 +788,19 @@
     },
     "hooker": {
       "version": "0.2.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/hooker/-/hooker-0.2.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.2.11",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.2.11.tgz",
       "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -810,13 +810,13 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "inquirer": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.9.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/inquirer/-/inquirer-0.9.0.tgz",
       "integrity": "sha1-c2bjijMeYZBJWKzlstpKml9jZ5g=",
       "dev": true,
       "requires": {
@@ -834,13 +834,13 @@
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
       "dev": true
     },
     "is-my-json-valid": {
       "version": "2.20.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
       "integrity": "sha1-XspqgjKmh/aIabc2G+FhLnUS5d8=",
       "dev": true,
       "requires": {
@@ -853,25 +853,25 @@
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
       "dev": true,
       "requires": {
@@ -881,7 +881,7 @@
       "dependencies": {
         "esprima": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/esprima/-/esprima-4.0.1.tgz",
           "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
           "dev": true
         }
@@ -889,13 +889,13 @@
     },
     "jsonpointer": {
       "version": "4.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/jsonpointer/-/jsonpointer-4.1.0.tgz",
       "integrity": "sha1-UB+4mYaiOJdlugnmBTKZzrTywsw=",
       "dev": true
     },
     "levn": {
       "version": "0.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/levn/-/levn-0.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/levn/-/levn-0.2.5.tgz",
       "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
       "dev": true,
       "requires": {
@@ -905,31 +905,31 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-3.10.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
       "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
       "dev": true
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
       "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
       "dev": true
     },
     "lodash._arraymap": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
       "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
@@ -939,7 +939,7 @@
     },
     "lodash._baseclone": {
       "version": "3.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "dev": true,
       "requires": {
@@ -953,13 +953,13 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basedifference": {
       "version": "3.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
       "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
       "dev": true,
       "requires": {
@@ -970,7 +970,7 @@
     },
     "lodash._baseflatten": {
       "version": "3.1.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
       "dev": true,
       "requires": {
@@ -980,31 +980,31 @@
     },
     "lodash._basefor": {
       "version": "3.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
       "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
       "dev": true
     },
     "lodash._baseindexof": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
       "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
       "dev": true
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
       "dev": true
     },
     "lodash._cacheindexof": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
       "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
       "dev": true
     },
     "lodash._createassigner": {
       "version": "3.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
@@ -1015,7 +1015,7 @@
     },
     "lodash._createcache": {
       "version": "3.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
       "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
       "dev": true,
       "requires": {
@@ -1024,25 +1024,25 @@
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash._pickbyarray": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
       "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
       "dev": true
     },
     "lodash._pickbycallback": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
       "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
       "dev": true,
       "requires": {
@@ -1052,7 +1052,7 @@
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
       "dev": true,
       "requires": {
@@ -1062,19 +1062,19 @@
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "3.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
       "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
       "dev": true,
       "requires": {
@@ -1085,13 +1085,13 @@
     },
     "lodash.istypedarray": {
       "version": "3.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
       "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -1102,7 +1102,7 @@
     },
     "lodash.keysin": {
       "version": "3.0.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
       "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
       "dev": true,
       "requires": {
@@ -1112,7 +1112,7 @@
     },
     "lodash.merge": {
       "version": "3.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.merge/-/lodash.merge-3.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.merge/-/lodash.merge-3.3.2.tgz",
       "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
       "dev": true,
       "requires": {
@@ -1131,7 +1131,7 @@
     },
     "lodash.omit": {
       "version": "3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.omit/-/lodash.omit-3.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.omit/-/lodash.omit-3.1.0.tgz",
       "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
       "dev": true,
       "requires": {
@@ -1147,13 +1147,13 @@
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
       "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
       "dev": true,
       "requires": {
@@ -1163,13 +1163,13 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
     "minimatch": {
       "version": "2.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "dev": true,
       "requires": {
@@ -1178,13 +1178,13 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimist/-/minimist-1.2.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
@@ -1193,31 +1193,31 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/mute-stream/-/mute-stream-0.0.4.tgz",
       "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
       "dev": true
     },
     "neo-async": {
       "version": "2.6.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/neo-async/-/neo-async-2.6.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "nopt": {
       "version": "1.0.10",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/nopt/-/nopt-1.0.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
@@ -1226,13 +1226,13 @@
     },
     "object-assign": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/object-assign/-/object-assign-2.1.1.tgz",
       "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -1241,7 +1241,7 @@
     },
     "optionator": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/optionator/-/optionator-0.5.0.tgz",
       "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
       "dev": true,
       "requires": {
@@ -1255,7 +1255,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -1263,31 +1263,31 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "dev": true,
       "requires": {
@@ -1302,7 +1302,7 @@
     },
     "readline2": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/readline2/-/readline2-0.1.1.tgz",
       "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
       "dev": true,
       "requires": {
@@ -1312,13 +1312,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/ansi-regex/-/ansi-regex-1.1.1.tgz",
           "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
           "dev": true
         },
         "strip-ansi": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-2.0.1.tgz",
           "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
           "dev": true,
           "requires": {
@@ -1329,13 +1329,13 @@
     },
     "resolve": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/resolve/-/resolve-0.3.1.tgz",
       "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
       "dev": true
     },
     "rimraf": {
       "version": "2.6.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rimraf/-/rimraf-2.6.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "dev": true,
       "requires": {
@@ -1344,7 +1344,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.6",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-7.1.6.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/glob/-/glob-7.1.6.tgz",
           "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
           "dev": true,
           "requires": {
@@ -1358,7 +1358,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
@@ -1369,7 +1369,7 @@
     },
     "run-async": {
       "version": "0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
@@ -1378,43 +1378,43 @@
     },
     "rx-lite": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-2.5.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/rx-lite/-/rx-lite-2.5.2.tgz",
       "integrity": "sha1-X+9C1Nbna6tRmdIXEyfbcJ5Y5jQ=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
@@ -1423,7 +1423,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -1432,31 +1432,31 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/through/-/through-2.3.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "to-double-quotes": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/to-double-quotes/-/to-double-quotes-1.0.2.tgz",
       "integrity": "sha1-u27TbHhjTD1k/YelGtWGDcWU7f0=",
       "dev": true,
       "requires": {
@@ -1465,7 +1465,7 @@
     },
     "to-single-quotes": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/to-single-quotes/-/to-single-quotes-1.0.4.tgz",
       "integrity": "sha1-LuqBma8myhFx9TV8WeGS1WXuUxM=",
       "dev": true,
       "requires": {
@@ -1474,13 +1474,13 @@
     },
     "type": {
       "version": "1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type/-/type-1.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type/-/type-1.2.0.tgz",
       "integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A=",
       "dev": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -1489,62 +1489,62 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.13.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/uglify-js/-/uglify-js-3.13.5.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/uglify-js/-/uglify-js-3.13.5.tgz",
       "integrity": "sha1-XXHW27pkz0QfMpKbHvznNlu08RM=",
       "dev": true,
       "optional": true
     },
     "underscore": {
       "version": "1.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore/-/underscore-1.7.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore/-/underscore-1.7.0.tgz",
       "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
       "dev": true
     },
     "underscore.string": {
       "version": "2.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-2.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
     },
     "user-home": {
       "version": "1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "which": {
       "version": "1.0.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/which/-/which-1.0.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/which/-/which-1.0.9.tgz",
       "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
       "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/write/-/write-0.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
@@ -1553,13 +1553,13 @@
     },
     "xml-escape": {
       "version": "1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/xml-escape/-/xml-escape-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/xml-escape/-/xml-escape-1.0.0.tgz",
       "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     }

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
                                 <nodeVersion>v14.17.0</nodeVersion>
                                 <npmVersion>6.14.13</npmVersion>
                                 <downloadRoot>https://nodejs.org/dist/</downloadRoot>
-                                <npmDownloadRoot>https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/npm/-/</npmDownloadRoot>
+                                <npmDownloadRoot>https://wrensecurity.jfrog.io/artifactory/api/npm/npm-virtual/npm/-/</npmDownloadRoot>
                             </configuration>
                         </execution>
 


### PR DESCRIPTION
WrenSecurity's Artifactory is now used for installing NPM dependencies:
- Registry URL was updated in all `package-lock.json` files.
- `.npmrc` was added so that newly added packages have correct registry URL.

Directory where all libs are copied to, before being included in the final artifact, moved to Maven's `target` dir, so that it can be properly removed by `mvn clean`.

Fixes #10 