### PR TITLE
Allow synchronous event dispatch

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade Guide
 
+## 23.0.x -> 23.1.x
+
+* ProcessConfiguration allows defining synchronous event handler when there are no dependencies.
+Downstream projects should prefer using synchronous event handlers as the legacy behavior might
+be removed in later releases.
+
+
 ## 22.1.x -> 23.x
 
 * Library files no longer contain version number in their name. Adding content hash or version

--- a/packages/base/src/scripts/config/process/CommonConfig.js
+++ b/packages/base/src/scripts/config/process/CommonConfig.js
@@ -18,8 +18,10 @@ define([
     "jquery",
     "lodash",
     "org/forgerock/commons/ui/common/util/Constants",
-    "org/forgerock/commons/ui/common/main/EventManager"
-], function($, _, Constants, EventManager) {
+    "org/forgerock/commons/ui/common/main/EventManager",
+    "org/forgerock/commons/ui/common/main/SpinnerManager",
+    "org/forgerock/commons/ui/common/main/ErrorsHandler"
+], function($, _, Constants, EventManager, spinner, errorsHandler) {
     var obj = [
         {
             startEvent: Constants.EVENT_APP_INITIALIZED,
@@ -158,11 +160,7 @@ define([
         {
             startEvent: Constants.EVENT_REST_CALL_ERROR,
             description: "",
-            dependencies: [
-                "org/forgerock/commons/ui/common/main/SpinnerManager",
-                "org/forgerock/commons/ui/common/main/ErrorsHandler"
-            ],
-            processDescription: function(event, spinner, errorsHandler) {
+            processDescription: function(event) {
                 errorsHandler.handleError(event.data, event.errorsHandlers);
                 spinner.hideSpinner();
             }
@@ -170,10 +168,7 @@ define([
         {
             startEvent: Constants.EVENT_START_REST_CALL,
             description: "",
-            dependencies: [
-                "org/forgerock/commons/ui/common/main/SpinnerManager"
-            ],
-            processDescription: function(event, spinner) {
+            processDescription: function(event) {
                 if (!event.suppressSpinner) {
                     spinner.showSpinner();
                 }
@@ -182,10 +177,7 @@ define([
         {
             startEvent: Constants.EVENT_END_REST_CALL,
             description: "",
-            dependencies: [
-                "org/forgerock/commons/ui/common/main/SpinnerManager"
-            ],
-            processDescription: function(event, spinner) {
+            processDescription: function() {
                 spinner.hideSpinner();
             }
         },

--- a/packages/base/src/scripts/org/forgerock/commons/ui/common/main/ProcessConfiguration.js
+++ b/packages/base/src/scripts/org/forgerock/commons/ui/common/main/ProcessConfiguration.js
@@ -36,12 +36,18 @@ define([
     });
 
     obj.callRegisterListenerFromConfig = function (config) {
+        var dependencies = _.map(config.dependencies, function (dep) {
+            return ModuleLoader.load(dep);
+        });
         eventManager.registerListener(config.startEvent, function (event) {
-            return $.when.apply($, _.map(config.dependencies, function (dep) {
-                return ModuleLoader.load(dep);
-            })).then(function () {
-                return config.processDescription.apply(this, [event].concat(_.toArray(arguments)));
-            });
+            if (dependencies.length) {
+                // legacy async processing
+                return $.when.apply($, dependencies).then(function () {
+                    return config.processDescription.apply(this, [event].concat(_.toArray(arguments)));
+                });
+            } else {
+                return config.processDescription(event);
+            }
         });
     };
 


### PR DESCRIPTION
This PR enables to have synchronous dispatch for event handlers defined via process configuration.

The previous `ProcessConfiguration` component had a strange race conditions when loading module dependencies that lead to out-of-order invocation of event handlers. This was apparent when showing and hiding loading spinner indicator.