### PR TITLE
Make event dispatch synchronous

### DIFF
--- a/packages/base/src/scripts/org/forgerock/commons/ui/common/main/EventManager.js
+++ b/packages/base/src/scripts/org/forgerock/commons/ui/common/main/EventManager.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 
 define([
@@ -21,28 +22,69 @@ define([
 
     var obj = {},
         eventRegistry = {},
-        subscriptions = {};
+        subscriptions = {},
+        whenCompleteWarned = false;
 
-    obj.sendEvent = function (eventId, event) {
-        return $.when.apply($,
+    // Surface handler errors to the global error handler (window.onerror) without
+    // aborting dispatch, matching how DOM EventTarget.dispatchEvent reports listener
+    // exceptions.
+    function reportError (error) {
+        window.setTimeout(function () {
+            throw error;
+        });
+    }
 
-            _.map(eventRegistry[eventId], function (eventHandler) {
-                var promise = $.Deferred();
-                window.setTimeout(function () {
-                    $.when(eventHandler(event)).always(promise.resolve);
-                });
-                return promise;
-            })
-
-        ).then(
-            function () {
-                var promise;
-                if (_.has(subscriptions, eventId)) {
-                    promise = subscriptions[eventId];
-                    delete subscriptions[eventId];
-                    promise.resolve();
+    function invokeHandler (handler, event) {
+        var deferred = $.Deferred();
+        try {
+            $.when(handler(event)).then(
+                function (value) { deferred.resolve(value); },
+                function (error) {
+                    reportError(error);
+                    deferred.resolve();
                 }
-                return;
+            );
+        } catch (error) {
+            reportError(error);
+            deferred.resolve();
+        }
+        return deferred.promise();
+    }
+
+    function deferHandler (handler, event) {
+        var deferred = $.Deferred();
+        window.setTimeout(function () {
+            invokeHandler(handler, event).always(deferred.resolve);
+        });
+        return deferred.promise();
+    }
+
+    /**
+     * Dispatch the given event to all registered listeners.
+     *
+     * Handlers are invoked synchronously by default. Pass `{ async: true }` to defer each
+     * handler to the next tick, matching the legacy dispatch behaviour.
+     *
+     * A handler that throws (or returns a rejected promise) does not abort dispatch;
+     * the error is re-thrown asynchronously so it reaches `window.onerror`.
+     *
+     * @param {string} eventId
+     * @param {*} [event]
+     * @param {{ async?: boolean }} [options]
+     * @returns {Promise} resolved once every handler has settled.
+     */
+    obj.sendEvent = function (eventId, event, options) {
+        const async = !!(options && options.async);
+        const results = _.map(eventRegistry[eventId], function (handler) {
+            return async ? deferHandler(handler, event) : invokeHandler(handler, event);
+        });
+        return $.when.apply($, results).then(
+            function () {
+                if (_.has(subscriptions, eventId)) {
+                    const subscription = subscriptions[eventId];
+                    delete subscriptions[eventId];
+                    subscription.resolve();
+                }
             }
         );
     };
@@ -69,8 +111,16 @@ define([
 
     /**
      * Returns a promise that will be resolved the next time the provided eventId has completed processing.
+     *
+     * @deprecated Await the promise returned by {@link sendEvent} instead.
      */
     obj.whenComplete = function (eventId) {
+        if (!whenCompleteWarned) {
+            whenCompleteWarned = true;
+            console.warn(
+                "EventManager.whenComplete is deprecated; await the promise returned by sendEvent instead."
+            );
+        }
         if (!_.has(subscriptions, eventId)) {
             subscriptions[eventId] = $.Deferred();
         }


### PR DESCRIPTION
Change event dispatch process from calling event handlers in an async (setTimeout) fashion to sync calls. This fixes potential race conditions when a specific order of event processing is expected (e.g. showing and hiding loading progress spinner).

Why I see this as a meaningful change? The decision to process any event in async fashion shuold be done by the event subscriber, not the event dispatcher / manager. Or potentially the triggering component might want to send event asynchronously... again, that decision should not be made by the dispatcher / manager. 