### PR TITLE
Fix pagination in AbstractCollection

### DIFF
--- a/packages/base/src/scripts/org/forgerock/commons/ui/common/main/AbstractCollection.js
+++ b/packages/base/src/scripts/org/forgerock/commons/ui/common/main/AbstractCollection.js
@@ -86,7 +86,7 @@ define([
                 // when we don't have a total, assume there are more results
                 (this.getPagingType() === "offset" && this.state.totalRecords === null) ||
                 (this.getPagingType() === "offset"
-                    && this.state.totalRecords >= ((this.state.currentPage+1) * this.state.pageSize));
+                    && this.state.totalRecords > ((this.state.currentPage+1) * this.state.pageSize));
         },
         hasNext: function () { // Legacy function to retain backward compatibility
             return this.hasNextPage();

--- a/packages/base/src/scripts/org/forgerock/commons/ui/common/main/AbstractCollection.js
+++ b/packages/base/src/scripts/org/forgerock/commons/ui/common/main/AbstractCollection.js
@@ -171,10 +171,12 @@ define([
             this.state.totalRecords = _.isFinite(resp.totalPagedResults) && resp.totalPagedResults > -1
                 ? resp.totalPagedResults : null;
 
-            if (!this.state.totalPages && this.state.totalRecords) {
+            if (this.state.totalRecords) {
                 this.state.totalPages = Math.ceil(this.state.totalRecords / this.state.pageSize);
+                this.state.lastPage = this.state.totalPages - 1;
             } else {
                 this.state.totalPages = null;
+                this.state.lastPage = null;
             }
         },
         parseRecords: function (resp) {

--- a/packages/base/src/scripts/org/forgerock/commons/ui/common/main/AbstractCollection.js
+++ b/packages/base/src/scripts/org/forgerock/commons/ui/common/main/AbstractCollection.js
@@ -75,15 +75,21 @@ define([
             }
         },
 
-        hasPrevious: function () {
+        hasPreviousPage: function () {
             return (this.getPagingType() === "offset" && this.state.currentPage >= 1);
         },
-        hasNext: function () {
+        hasPrevious: function () { // Legacy function to retain backward compatibility
+            return this.hasPreviousPage();
+        },
+        hasNextPage: function () {
             return (this.getPagingType() === "cookie" && this.state.pagedResultsCookie !== null) ||
                 // when we don't have a total, assume there are more results
                 (this.getPagingType() === "offset" && this.state.totalRecords === null) ||
                 (this.getPagingType() === "offset"
                     && this.state.totalRecords >= ((this.state.currentPage+1) * this.state.pageSize));
+        },
+        hasNext: function () { // Legacy function to retain backward compatibility
+            return this.hasNextPage();
         },
         sync: function (method, collection, options) {
             if (method === "read") {
@@ -138,7 +144,7 @@ define([
             return BackbonePaginator.prototype.getNextPage.apply(this, arguments);
         },
         getPreviousPage: function () {
-            if (!this.hasPrevious()) {
+            if (!this.hasPreviousPage()) {
                 return this.getFirstPage();
             }
             // this only works with offset-based paging

--- a/packages/base/tests/qunit/AbstractCollection.js
+++ b/packages/base/tests/qunit/AbstractCollection.js
@@ -63,7 +63,7 @@ define([
             assert.equal(testCollection.length, 2, "collection contains two records from the backend");
             assert.equal(testCollection.where({givenName: "Boaty"}).length, 1,
                 "able to find expected model content in collection");
-            assert.ok(testCollection.hasNext(), "response with cookie indicates that hasNext is true");
+            assert.ok(testCollection.hasNextPage(), "response with cookie indicates that hasNextPage is true");
             assert.equal(testCollection.state.totalRecords, 5, "Total records correctly populated in collection state");
             assert.equal(testCollection.state.totalPages, 3, "Total pages correctly populated in collection state");
             assert.equal(restCallArg.url, "/crestResource", "correct url used to query backend");


### PR DESCRIPTION
This PR provides the following fixes related to the pagination in the `AbstractCollection` component:

* Added missing `hasPreviousPage` and `hasNextPage` functions needed after `backgrid-paginator` upgrade
* Fixed check if next page is available when number of records equals page size
* Fixed invalid deleting of `totalPages` value when processing response
* Added setting of the `lastPage` state attribute to allow correct rendering of the last page button