### PR TITLE
Fix module dependecies load

### DIFF
--- a/packages/base/src/scripts/org/forgerock/commons/ui/common/main/ProcessConfiguration.js
+++ b/packages/base/src/scripts/org/forgerock/commons/ui/common/main/ProcessConfiguration.js
@@ -36,12 +36,12 @@ define([
     });
 
     obj.callRegisterListenerFromConfig = function (config) {
-        var dependencies = _.map(config.dependencies, function (dep) {
-            return ModuleLoader.load(dep);
-        });
         eventManager.registerListener(config.startEvent, function (event) {
-            if (dependencies.length) {
+            if (config.dependencies && config.dependencies.length) {
                 // legacy async processing
+                var dependencies = _.map(config.dependencies, function (dep) {
+                    return ModuleLoader.load(dep);
+                });
                 return $.when.apply($, dependencies).then(function () {
                     return config.processDescription.apply(this, [event].concat(_.toArray(arguments)));
                 });


### PR DESCRIPTION
This PR resolves an issue with loading module dependencies. The module's required dependencies are loaded after the start event is triggered. Currently, all dependencies for all modules are loaded during initialization.