### PR TITLE
Upgrade requirejs to 2.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8124,9 +8124,10 @@
       "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug=="
     },
     "node_modules/requirejs": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
-      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
+      "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==",
+      "license": "MIT",
       "bin": {
         "r_js": "bin/r.js",
         "r.js": "bin/r.js"
@@ -10048,7 +10049,7 @@
         "moment": "^2.29.4",
         "react": "^16.9.0",
         "react-dom": "^16.9.0",
-        "requirejs": "^2.3.6",
+        "requirejs": "^2.3.7",
         "spin.js": "^2.3.2",
         "titatoggle": "^2.1.2",
         "xdate": "^0.8.2"
@@ -10106,7 +10107,7 @@
         "less": "^4.2.0",
         "postcss": "^8.4.31",
         "postcss-minify": "^1.1.0",
-        "requirejs": "^2.3.6",
+        "requirejs": "^2.3.7",
         "rimraf": "^5.0.5",
         "rollup": "^4.6.0"
       }
@@ -10115,7 +10116,7 @@
       "name": "@wrensecurity/commons-ui-mock",
       "dependencies": {
         "qunit": "^2.20.0",
-        "requirejs": "^2.3.6",
+        "requirejs": "^2.3.7",
         "sinon": "^17.0.1"
       },
       "devDependencies": {

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -39,7 +39,7 @@
     "moment": "^2.29.4",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
-    "requirejs": "^2.3.6",
+    "requirejs": "^2.3.7",
     "spin.js": "^2.3.2",
     "titatoggle": "^2.1.2",
     "xdate": "^0.8.2"

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -29,7 +29,7 @@
     "less": "^4.2.0",
     "postcss": "^8.4.31",
     "postcss-minify": "^1.1.0",
-    "requirejs": "^2.3.6",
+    "requirejs": "^2.3.7",
     "rimraf": "^5.0.5",
     "rollup": "^4.6.0"
   },

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "qunit": "^2.20.0",
-    "requirejs": "^2.3.6",
+    "requirejs": "^2.3.7",
     "sinon": "^17.0.1"
   },
   "overrides": {


### PR DESCRIPTION
This PR upgrades `requirejs` dependency to resolve the security vulnerabilities.